### PR TITLE
Sync new features and fixes from strapsai/airlab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,6 @@ The scripts only depend on `$AIRLAB_PATH` being set (from an existing install).
 
 ## Known Issues
 
-- `set_hosts` command is referenced in the main entrypoint but no implementation file exists.
 - `robot-launch` uses `error_exit()` which is not defined in that file (should be `log_error` + `exit 1`).
 - `docker-join` default `CONTAINER_NAME` is `"docker-compose.yml"` which is a filename, not a container name.
 - `robot-sync` port extraction logic (lines ~303-311) is fragile for addresses with ports.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     *   [SSH](#ssh)
     *   [Auth](#auth)
     *   [set_env](#set_env)
+    *   [set_hosts](#set_hosts)
     *   [Sync](#sync)
     *   [Launch](#launch)
     *   [Docker Commands](#docker-commands)
@@ -34,6 +35,7 @@
 *   **File Synchronization:**  Provides an easy and efficient method for transferring files between local and remote systems.
 *   **Launch Management:** Simplifies the process of launching and managing robotic system launch files, especially using `tmux` sessions.
 *   **Environment Setup:** Automates the configuration of necessary environments on remote systems.
+*   **Multi-Repository Workflows:** Beyond `vcstool`'s init/pull/push/status, the `vcs` family also supports cross-workspace **drift detection** (`airlab vcs check`), **recursive tagging with deduplicated push** (`airlab vcs tag`), and **recursive branch / tag checkout with a colored post-state summary** (`airlab vcs checkout`), which are essential when the same source repository is cloned across many sub-workspaces.
 *   **Unified Interface:** Consolidates various tools and processes into a single command-line utility.
 *   **Debian Package:**  Offers a simple and reliable installation and update mechanism via a Debian package.
 
@@ -85,6 +87,16 @@
 
     The `--skip-venv` option is useful when you manage your own virtual environment (e.g., conda, poetry, or a shared team venv). It requires that a virtual environment is already active in the current terminal session. Python dependencies will be installed into that active venv instead of creating `~/VENVs/airlab`.
 
+    **Skip apt installs:**
+
+    If you've already installed the apt dependencies (or want to manage them yourself), use `--skip-apt` to skip both `sudo apt update` and `sudo apt install` in `install.sh` and `install_dependencies_ubuntu24.sh`:
+
+    ```bash
+    ./install.sh --skip-apt
+    ```
+
+    This flag can be combined with the venv flags, e.g., `./install.sh --skip-venv --skip-apt`.
+
 3.  **(Optional) Install Missing Dependencies:** This command can attempt to fix broken installations by installing missing dependencies. While it can be helpful, it's generally more reliable to ensure all prerequisites are installed beforehand.
 
     ```bash
@@ -110,18 +122,20 @@ After installing airlab you can run the command to setup the environment `airlab
 *   **Paths:** `airlab sync <robot> --path=<TAB>` and `--exclude=<TAB>` complete with files and directories under `$AIRLAB_PATH`.
 *   **Docker containers:** `airlab docker-join --name=<TAB>` completes with currently running Docker container names.
 *   **VCS repo files:** `airlab vcs init --repo_file=<TAB>` completes with `.yaml`/`.yml` files (and subdirectories) under `$AIRLAB_PATH/version_control/`.
-*   **VCS sub-commands:** `airlab vcs <TAB>` lists `init`, `pull`, `push`, `status`, and `update`, each with their own option completions.
+*   **VCS sub-commands:** `airlab vcs <TAB>` lists `init`, `pull`, `push`, `status`, `update`, `check`, `tag`, and `checkout`, each with their own option completions.
 
-To manually reload the completion script (e.g., during development):
+**After installing or upgrading `airlab`**, run the appropriate snippet below so your shell picks up the new completion file. This is also the fix if you ever see stale or missing completions (e.g. `airlab ssh <TAB>` not listing robots after an upgrade):
 
 ```bash
 # Bash
 source /etc/bash_completion.d/airlab
 
-# Zsh (clear cache and restart)
+# Zsh — clear the compiled compdump cache and restart the shell
 rm -f ~/.zcompdump*
 exec zsh
 ```
+
+The zsh snippet is needed because zsh caches a compiled completion-function table in `~/.zcompdump*`; an upgraded `_airlab` on disk is only picked up after the cache is invalidated (some zsh frameworks like oh-my-zsh / prezto skip the freshness check by default).
 
 ## Commands
 
@@ -320,6 +334,54 @@ airlab set_env robot1 MY_VAR="hello"
 
 ---
 
+### set_hosts
+
+Updates `/etc/hosts` with hostname-to-IP mappings from `robot.conf`, so you can reach robots by name (e.g., `ping mt001`).
+
+#### Usage
+
+```bash
+airlab set_hosts local [--help]
+
+airlab set_hosts <robot_name> [--password] [--help]
+```
+
+#### Arguments
+
+*   `local`: Update the local machine's `/etc/hosts`.
+*   `<robot_name>`: Update `/etc/hosts` on a remote robot via SSH.
+
+#### Options
+
+*   `--password`: Skip key-based SSH authentication and prompt for a password directly (remote targets only).
+*   `--help`: Show help message.
+
+#### Quick Examples
+
+```bash
+airlab set_hosts local              # Update local /etc/hosts
+airlab set_hosts mt001              # Update /etc/hosts on mt001
+airlab set_hosts mt001 --password   # Use password authentication
+```
+
+#### Features
+
+*   Reads `robot.conf` entries and generates `/etc/hosts` lines mapping robot names to their IPs.
+*   Skips `ssh://` URI entries (e.g., `ssh://user@host:port` for port-forwarded connections), since they share a single hostname with different ports and don't map to unique IPs.
+*   Creates a timestamped backup before modifying `/etc/hosts` (e.g., `/etc/hosts_20260429_160345`).
+*   Uses fenced markers (`# Airlab Hosts Start` / `# Airlab Hosts End`) — if markers exist, only the content between them is replaced.
+*   Checks for hostname and IP conflicts with existing entries outside the markers. If conflicts are found, warns and aborts.
+*   Supports both local and remote targets with full SSH key/password authentication.
+
+#### Dependencies
+
+*   `ssh`, `sshpass` (for remote targets)
+*   `sudo` (required to modify `/etc/hosts`)
+
+Detailed documentation is available [here](/usr/local/bin/docs/set_hosts.md).
+
+---
+
 ### Sync
 
 This command synchronizes files between the local machine and a remote robot.
@@ -513,6 +575,31 @@ airlab docker-up [OPTIONS]
 *   `--password`: Skip key-based SSH authentication and prompt for a password directly.
 *   `--help`: Display help message.
 
+#### docker-clean
+
+Stops and removes **all** Docker containers (running or stopped) on the local machine or a remote robot. Equivalent to `docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)`, but no-ops cleanly when there are no containers. Prompts for confirmation by default since this is destructive.
+
+##### Usage
+
+```bash
+airlab docker-clean [OPTIONS]
+```
+
+##### Options
+
+*   `--system=<system_name>`: Target system for remote operations.
+*   `--yes`, `-y`: Skip the confirmation prompt.
+*   `--password`: Skip key-based SSH authentication and prompt for a password directly.
+*   `--help`: Display help message.
+
+##### Quick Examples
+
+```bash
+airlab docker-clean                  # local, with confirmation
+airlab docker-clean --yes            # local, no prompt
+airlab docker-clean --system=mt001   # clean every container on mt001
+```
+
 #### Common Features
 
 *   **Remote Operations**: Requires a valid system definition in `robot.conf`, SSH credentials, and correct configuration in `robot_info.yaml`.
@@ -566,7 +653,7 @@ airlab vcs pull [OPTIONS]
 
 #### push
 
-Pushes local changes to remote repositories.
+Pushes local changes to remote repositories. With `--tags=<name>`, pushes a single named tag instead of branch refs, deduplicated by remote URL with the same drift gate as [`tag --push`](#tag).
 
 ##### Usage
 
@@ -576,7 +663,19 @@ airlab vcs push [OPTIONS]
 
 ##### Options
 
+*   `--tags=<name>`: Push the named tag (instead of branch refs). Walks the current directory, finds git repositories (skipping submodules), groups them by normalized remote URL, and runs `git push origin refs/tags/<name>` once per unique URL. Refuses if any group's clones have the tag pointing at different commits, unless `--force` is also given.
+*   `--force`: With `--tags=`, overwrite the remote tag and skip the drift gate.
+*   `--dry-run`: With `--tags=`, show what would be pushed without actually pushing.
 *   `--help`: Display help message.
+
+##### Quick Examples
+
+```bash
+airlab vcs push                       # push branch refs (vcstool default)
+airlab vcs push --tags=v1.0.0         # push tag v1.0.0, deduped by URL
+airlab vcs push --tags=v1.0.0 --dry-run
+airlab vcs push --tags=v1.0.0 --force # overwrite remote, skip drift gate
+```
 
 #### status
 
@@ -612,6 +711,160 @@ airlab vcs update [OPTIONS]
 1.  Pull all existing repos (stops on first failure).
 2.  Run `airlab vcs init --here` to clone any missing repos.
 3.  Pull all repos again (collects failures and shows a summary).
+
+#### check
+
+Find repository drift in two complementary modes. Run before `airlab vcs tag` to make sure shared clones agree.
+
+##### Usage
+
+```bash
+airlab vcs check [OPTIONS]
+```
+
+##### Modes
+
+*   **Default (filesystem mode):** Walks the current directory recursively, finds every git repository (skipping submodules and linked worktrees), groups them by normalized remote URL, and flags any group whose clones are not all on the same commit. Equivalent ssh and https URLs collapse to the same group. Output is split into `[DRIFT]` (red), `[BRANCH SKEW]` (yellow), `[OK]` (green), `[NO ORIGIN]`, and `[DIRTY]` sections.
+*   **`--version-control` mode:** Reads every YAML file under `$AIRLAB_PATH/version_control/`. Flags any URL pinned to multiple `version:` values across YAMLs (`[VERSION DRIFT]`) and any duplicate URLs within a single YAML (`[DUPLICATE URL]`).
+
+##### Options
+
+*   `--version-control`: Scan YAMLs in `$AIRLAB_PATH/version_control/` instead of walking PWD.
+*   `--no-progress`: Disable the progress bar (also auto-disabled when stderr is not a terminal).
+*   `--help`: Display help message.
+
+##### Exit Codes
+
+*   `0`: No drift / no duplicates found.
+*   `1`: Drift, duplicate URLs, or YAML parse errors detected — usable in scripts and CI.
+
+##### Quick Examples
+
+```bash
+airlab cd && airlab vcs check         # walk the workspace, flag commit drift
+airlab vcs check --version-control    # cross-YAML version drift + intra-YAML dupes
+airlab vcs check --no-progress        # piped/CI-friendly run
+```
+
+#### tag
+
+Recursively create a git tag at HEAD of every repository under the current directory, skipping submodules. Optionally push the tag to origin once per unique remote URL (deduplicated, with a drift gate).
+
+##### Usage
+
+```bash
+airlab vcs tag <tag_name> [OPTIONS]
+```
+
+##### Arguments
+
+*   `<tag_name>`: Name of the tag to create (e.g. `v1.0.0`).
+
+##### Options
+
+*   `-m, --message=<msg>`: Annotated tag message. Default: `airlab vcs tag <name> on <ISO date>`.
+*   `--lightweight`: Create a lightweight tag (no message). Mutually exclusive with `-m` / `--message`.
+*   `--force`: Overwrite an existing local tag. With `--push`, also overwrites the remote tag and skips the drift gate.
+*   `--push`: After tagging, push the tag to origin once per unique remote URL. Refuses to push if shared clones are not on the same commit, unless `--force` is also set. The repository with the lexicographically smallest path is chosen as the source for each push.
+*   `--dry-run`: Print what would be done without making any changes.
+*   `--no-progress`: Disable the progress bar (also auto-disabled when stderr is not a terminal).
+*   `--help`: Display help message.
+
+##### Behavior
+
+*   Annotated tags by default; the auto-generated message records the tag name and an ISO-8601 UTC timestamp.
+*   A dirty working tree triggers a `[WARN]` line but does not block tagging — the tag attaches to whatever HEAD currently points at.
+*   With `--push`, a repo cloned in N workspaces is pushed exactly once. The drift gate refuses publication if the same logical repo has different SHAs across workspaces.
+
+##### Recommended Workflow
+
+```bash
+airlab cd
+airlab vcs check                      # confirm no [DRIFT]
+airlab vcs tag v1.0.0 --push          # tag everything and publish, deduped
+```
+
+If you want to tag now and push later:
+
+```bash
+airlab vcs tag v1.0.0
+airlab vcs push --tags=v1.0.0
+```
+
+##### Quick Examples
+
+```bash
+airlab vcs tag v1.0.0                                # annotated tag, no push
+airlab vcs tag v1.0.0 --message="release 1.0"        # custom message
+airlab vcs tag v1.0.0 --lightweight                  # lightweight tag
+airlab vcs tag v1.0.0 --push                         # tag + dedup-push
+airlab vcs tag v1.0.0 --push --force                 # overwrite remote tag
+airlab vcs tag v1.0.0 --dry-run                      # preview only
+```
+
+#### `airlab vcs checkout <ref>` — Recursive Branch / Tag Checkout
+
+Recursively run `git checkout <ref>` in every repository under the current directory, skipping submodules. `<ref>` may be a branch or tag. After each checkout, the new state is summarized in a colored table.
+
+##### Usage
+
+```bash
+airlab vcs checkout <ref> [OPTIONS]
+```
+
+##### Arguments
+
+*   `<ref>`: Branch or tag name to check out.
+
+##### Options
+
+*   `--no-fetch`: Skip `git fetch --tags origin` before checkout. Faster, but tag availability and ahead/behind counts may be stale.
+*   `--force`, `-f`: Pass `-f` to `git checkout`, discarding local uncommitted changes. Use with care.
+*   `--no-progress`: Disable the progress bar (also auto-disabled when stderr is not a terminal).
+*   `--help`: Display help message.
+
+##### Behavior
+
+*   Walks PWD with the same logic as `airlab vcs check` (skips submodules and linked worktrees).
+*   Fetches `--tags` from `origin` per repo unless `--no-fetch` (so tag availability and ahead/behind are accurate).
+*   If `<ref>` exists on `origin` but not yet locally, git's DWIM creates a tracking branch.
+*   If `<ref>` is a tag, the result is a detached HEAD (reported as `on tag`).
+*   If `<ref>` does not exist on the repo (no local branch, no tag, no `origin/<ref>`), the row reports `ref MISSING`.
+*   Dirty trees that would be clobbered are reported as `FAILED (dirty)` and skipped; `--force` overrides.
+*   After each successful checkout, ahead/behind upstream is computed (when on a branch with tracking), and submodule SHA changes are counted.
+
+##### Output
+
+Per-repo row colored by status:
+
+*   **green** `ok` — checked out, on ref, up to date (or no remote to compare).
+*   **yellow** `warn` — checked out but ahead/behind upstream, or submodule SHAs changed.
+*   **red** `err` — `ref MISSING`, `FAILED`, `FAILED (dirty)`, or `fetch FAILED`.
+
+Rows are sorted err → warn → ok. A summary line counts each status bucket. Exit code is 0 only when every row is `ok`.
+
+##### Quick Examples
+
+```bash
+airlab vcs checkout main                  # branch checkout in every repo (fetches first)
+airlab vcs checkout v1.0.0                # tag checkout; missing-tag repos are flagged
+airlab vcs checkout strapsai/main         # also a branch — pulled from origin if needed
+airlab vcs checkout main --no-fetch       # already fetched recently, skip
+airlab vcs checkout main --force          # discard local uncommitted changes
+```
+
+#### Progress Bar
+
+`vcs check` (filesystem mode), `vcs tag`, and `vcs checkout` show a progress bar on stderr during their silent phases — the directory walk and the per-repo `git` invocations. Across hundreds of repositories these phases would otherwise look hung.
+
+```
+[████████░░░░░░░░░░░░] 145/347  inspecting: ws/src/path/to/repo
+```
+
+*   Stderr only, so piped/redirected stdout stays clean.
+*   Auto-disabled when stderr is not a TTY.
+*   `--no-progress` flag forces it off even on a TTY (useful in CI / scripts).
+*   The tag and push **execution** loops are not wrapped — they already emit one `✓` / `✗` line per repository.
 
 #### Common Features
 

--- a/etc/bash_completion.d/airlab
+++ b/etc/bash_completion.d/airlab
@@ -171,7 +171,7 @@ _airlab_completions() {
 
     # Top-level commands
     local commands="greet setup ssh auth ping sync launch set_env set_hosts \
-docker-build docker-up docker-join docker-list vcs cd --help --version"
+docker-build docker-up docker-join docker-list docker-clean vcs cd --help --version"
 
     # Position 1: complete the sub-command
     if [[ $cword -eq 1 ]]; then
@@ -250,6 +250,14 @@ docker-build docker-up docker-join docker-list vcs cd --help --version"
             fi
             ;;
 
+        set_hosts)
+            if [[ $cword -eq 2 ]]; then
+                COMPREPLY=( $(compgen -W "$(_airlab_targets) --help" -- "$cur") )
+                return
+            fi
+            COMPREPLY=( $(compgen -W "--password --help" -- "$cur") )
+            ;;
+
         docker-build)
             COMPREPLY=( $(compgen -W "--system= --compose= --password --help" -- "$cur") )
             ;;
@@ -270,13 +278,17 @@ docker-build docker-up docker-join docker-list vcs cd --help --version"
             COMPREPLY=( $(compgen -W "--system= --images --password --help" -- "$cur") )
             ;;
 
+        docker-clean)
+            COMPREPLY=( $(compgen -W "--system= --yes -y --password --help" -- "$cur") )
+            ;;
+
         cd)
             _airlab_complete_cd
             return
             ;;
 
         vcs)
-            local vcs_commands="init pull push status update --help"
+            local vcs_commands="init pull push status update check tag checkout --help"
 
             # Position 2: vcs sub-command
             if [[ $cword -eq 2 ]]; then
@@ -298,13 +310,26 @@ docker-build docker-up docker-join docker-list vcs cd --help --version"
                     COMPREPLY=( $(compgen -W "--no-rebase --help" -- "$cur") )
                     ;;
                 push)
-                    COMPREPLY=( $(compgen -W "--help" -- "$cur") )
+                    COMPREPLY=( $(compgen -W "--tags= --force --dry-run --help" -- "$cur") )
                     ;;
                 status)
                     COMPREPLY=( $(compgen -W "--show-branch --help" -- "$cur") )
                     ;;
                 update)
                     COMPREPLY=( $(compgen -W "--help" -- "$cur") )
+                    ;;
+                check)
+                    COMPREPLY=( $(compgen -W "--version-control --no-progress --help" -- "$cur") )
+                    ;;
+                tag)
+                    # Tag name is a free-text positional; no completion source.
+                    # After the tag name, complete option flags.
+                    COMPREPLY=( $(compgen -W "--message= --lightweight --force --push --dry-run --no-progress --help" -- "$cur") )
+                    ;;
+                checkout)
+                    # <ref> is a free-text positional; no completion source.
+                    # After the ref, complete option flags.
+                    COMPREPLY=( $(compgen -W "--no-fetch --force --no-progress --help" -- "$cur") )
                     ;;
             esac
             ;;

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -e  # Exit immediately if a command exits with a non-zero status
 
 # Parse command line arguments.
 VENV_MODE=""  # "", "override", "no-override", or "skip"
+SKIP_APT=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --override-venv)
@@ -18,9 +19,13 @@ while [[ $# -gt 0 ]]; do
             VENV_MODE="skip"
             shift
             ;;
+        --skip-apt)
+            SKIP_APT=true
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--override-venv | --no-override-venv | --skip-venv]"
+            echo "Usage: $0 [--override-venv | --no-override-venv | --skip-venv] [--skip-apt]"
             exit 1
             ;;
     esac
@@ -29,13 +34,17 @@ done
 # Get the directory of the current script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Update package lists
-sudo apt update
+if [ "$SKIP_APT" = true ]; then
+    echo "Skipping apt update and apt install (--skip-apt)."
+else
+    # Update package lists
+    sudo apt update
 
-# Install apt dependencies
-sudo apt install -y \
-    python3-pip \
-    python3-venv
+    # Install apt dependencies
+    sudo apt install -y \
+        python3-pip \
+        python3-venv
+fi
 
 # Handle venv setup.
 VENV_DIR="$HOME/VENVs"
@@ -104,7 +113,11 @@ fi
 
 # Go back to the script directory and run the Ubuntu 24 dependencies installation script.
 cd "$SCRIPT_DIR"
-bash install_dependencies_ubuntu24.sh
+DEP_ARGS=()
+if [ "$SKIP_APT" = true ]; then
+    DEP_ARGS+=(--skip-apt)
+fi
+bash install_dependencies_ubuntu24.sh "${DEP_ARGS[@]}"
 
 # Create the DEB package from a clean staging directory so that only
 # DEBIAN/, etc/, and usr/ end up in the package. Building directly from
@@ -120,6 +133,27 @@ if [ -z "$STAGING_DIR" ] || [ ! -d "$STAGING_DIR" ] || [ "$STAGING_DIR" = "/" ] 
 fi
 trap 'rm -rf "$STAGING_DIR"' EXIT
 cp -a "$SCRIPT_DIR/DEBIAN" "$SCRIPT_DIR/etc" "$SCRIPT_DIR/usr" "$STAGING_DIR/"
+
+# Auto-detect install source from this checkout's git origin and overwrite the
+# staged usr/share/airlab/install_source. This means a fork's local rebuild
+# always produces a .deb pointing at that fork, regardless of what the in-repo
+# file says — so a cross-fork merge that drags the wrong install_source value
+# in is self-correcting on next build. If origin can't be parsed (no .git, or
+# a non-GitHub remote), we leave the static file value in place as the fallback.
+if origin_url=$(git -C "$SCRIPT_DIR" remote get-url origin 2>/dev/null); then
+    detected="${origin_url#*github.com}"
+    detected="${detected#:}"
+    detected="${detected#/}"
+    [[ "$detected" =~ ^[0-9]+/ ]] && detected="${detected#*/}"
+    detected="${detected%.git}"
+    detected="${detected%/}"
+    if [[ "$detected" =~ ^[A-Za-z0-9_-]+/[A-Za-z0-9_.-]+$ ]]; then
+        mkdir -p "$STAGING_DIR/usr/share/airlab"
+        echo "$detected" > "$STAGING_DIR/usr/share/airlab/install_source"
+        echo "Recorded install source from git origin: $detected"
+    fi
+fi
+
 dpkg-deb --build "$STAGING_DIR" "$SCRIPT_DIR/../airlab.deb"
 
 # Install the DEB package.

--- a/install_dependencies_ubuntu24.sh
+++ b/install_dependencies_ubuntu24.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Parse command line arguments.
+SKIP_APT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-apt)
+            SKIP_APT=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--skip-apt]"
+            exit 1
+            ;;
+    esac
+done
+
 # Check if running under a Python virtual environment
 if [ -z "$VIRTUAL_ENV" ]; then
     echo "Error: This script must be run from within a Python virtual environment."
@@ -16,8 +32,12 @@ echo "  Location: $VIRTUAL_ENV"
 echo ""
 
 # Install Ubuntu dependencies.
-sudo apt-get install -y \
-    curl dpkg-dev git lsb-release openssh-server rsync sshpass tmux tmuxp
+if [ "$SKIP_APT" = true ]; then
+    echo "Skipping apt-get install (--skip-apt)."
+else
+    sudo apt-get install -y \
+        curl dpkg-dev git lsb-release openssh-server rsync sshpass tmux tmuxp
+fi
 
 # With the Python venv.
 pip install pyyaml vcstool "setuptools<=81.0.0"

--- a/usr/local/bin/airlab
+++ b/usr/local/bin/airlab
@@ -17,6 +17,7 @@ function show_usage() {
     echo "  docker-up                     Start Docker containers using docker-compose."
     echo "  docker-join                   Attach to a running Docker container."
     echo "  docker-list                   List active Docker containers."
+    echo "  docker-clean                  Stop and remove all Docker containers."
     echo "  vcs                           Manage multiple repositories with common git functions."
     echo "  ping                          Ping a remote robot."
     echo "  ssh                           Connect to a remote machine using SSH."
@@ -74,7 +75,11 @@ case "$COMMAND" in
     docker-list)
         # List Docker containers in the right place
         /usr/local/bin/cmds/docker-list "$@"
-        ;; 
+        ;;
+    docker-clean)
+        # Stop and remove all Docker containers
+        /usr/local/bin/cmds/docker-clean "$@"
+        ;;
     vcs)
         # Do git operations on multiple repositories
         /usr/local/bin/cmds/version-control/vcs "$@"

--- a/usr/local/bin/cmds/docker-clean
+++ b/usr/local/bin/cmds/docker-clean
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -uo pipefail
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Logging functions
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+show_usage() {
+    echo -e "${YELLOW}Usage:${NC}"
+    echo "  airlab docker-clean [--system=<system_name>] [--yes]"
+    echo
+    echo "Stops and removes ALL Docker containers (running or stopped)."
+    echo "Equivalent to: docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q)"
+    echo
+    echo -e "${YELLOW}Options:${NC}"
+    echo "  --system=<system_name>    Run against a remote robot listed in robot.conf."
+    echo "  --yes, -y                 Skip the confirmation prompt."
+    echo "  --password                Skip key-based SSH and prompt for password directly."
+    echo "  --help                    Display this help message."
+    echo
+    echo -e "${YELLOW}Examples:${NC}"
+    echo "  airlab docker-clean"
+    echo "  airlab docker-clean --yes"
+    echo "  airlab docker-clean --system=robot1"
+}
+
+ssh_authenticate() {
+    local ssh_address=$1
+    local force_password=${2:-false}
+    robot_password=""
+
+    if [[ "$force_password" == false ]]; then
+        log_info "Attempting key-based SSH to $ssh_address..."
+        if ssh -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o BatchMode=yes "$ssh_address" exit 2>/dev/null; then
+            log_info "Key-based SSH connection successful"
+            return 0
+        fi
+        log_warn "Key-based SSH failed. Falling back to password authentication."
+    fi
+
+    if ! command -v sshpass >/dev/null 2>&1; then
+        log_error "Key-based SSH failed and 'sshpass' is not installed for password fallback."
+        log_error "Either set up SSH keys or install sshpass: sudo apt install sshpass"
+        return 1
+    fi
+
+    log_info "Enter password for $ssh_address:"
+    read -s robot_password
+    [[ -z "$robot_password" ]] && log_error "Password cannot be empty" && return 1
+    echo
+
+    if ! sshpass -p "$robot_password" ssh -o ConnectTimeout=15 -o StrictHostKeyChecking=no "$ssh_address" exit; then
+        log_error "Cannot connect to remote system '$ssh_address'"
+        return 1
+    fi
+    log_info "SSH connection successful"
+    return 0
+}
+
+check_dependencies() {
+    local deps=("docker" "ssh")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+}
+
+# The shell snippet executed locally or remotely. Lists all containers,
+# exits cleanly when there are none, otherwise stops then removes them.
+clean_script() {
+    cat <<'EOF'
+set -u
+ids=$(docker ps -a -q)
+if [ -z "$ids" ]; then
+    echo "[INFO] No containers to clean."
+    exit 0
+fi
+echo "[INFO] Stopping containers..."
+docker stop $ids
+echo "[INFO] Removing containers..."
+docker rm $ids
+EOF
+}
+
+confirm() {
+    local target_label=$1
+    echo -ne "${YELLOW}This will stop and remove ALL Docker containers on ${target_label}. Continue? [y/N]${NC} "
+    local reply
+    read -r reply
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+main() {
+    check_dependencies
+
+    local SYSTEM_NAME=""
+    local FORCE_PASSWORD=false
+    local ASSUME_YES=false
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --system=*)
+                SYSTEM_NAME="${1#--system=}"
+                ;;
+            --yes|-y)
+                ASSUME_YES=true
+                ;;
+            --password)
+                FORCE_PASSWORD=true
+                ;;
+            --help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                log_error "Invalid option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    local script
+    script=$(clean_script)
+
+    if [[ -n "$SYSTEM_NAME" ]]; then
+        local ROBOT_CONF="$AIRLAB_PATH/robot/robot.conf"
+        if [[ ! -f "$ROBOT_CONF" ]]; then
+            log_error "Robot configuration file not found at '$ROBOT_CONF'"
+            exit 1
+        fi
+
+        local ROBOT_SSH_ADDRESS
+        ROBOT_SSH_ADDRESS=$(grep "^$SYSTEM_NAME=" "$ROBOT_CONF" | cut -d= -f2)
+        if [[ -z "$ROBOT_SSH_ADDRESS" ]]; then
+            log_error "System '$SYSTEM_NAME' not found in $ROBOT_CONF"
+            exit 1
+        fi
+
+        if [[ "$ASSUME_YES" != true ]]; then
+            confirm "$SYSTEM_NAME ($ROBOT_SSH_ADDRESS)" || { log_info "Aborted."; exit 0; }
+        fi
+
+        robot_password=""
+        if ! ssh_authenticate "$ROBOT_SSH_ADDRESS" "$FORCE_PASSWORD"; then
+            exit 1
+        fi
+
+        local SSHPASS_PREFIX=()
+        if [[ -n "$robot_password" ]]; then
+            SSHPASS_PREFIX=(sshpass -p "$robot_password")
+        fi
+
+        log_info "Cleaning Docker containers on $ROBOT_SSH_ADDRESS"
+        if ! "${SSHPASS_PREFIX[@]}" ssh "$ROBOT_SSH_ADDRESS" "bash -s" <<<"$script"; then
+            log_error "Failed to clean docker containers on $SYSTEM_NAME"
+            exit 1
+        fi
+    else
+        if [[ "$ASSUME_YES" != true ]]; then
+            confirm "the local system" || { log_info "Aborted."; exit 0; }
+        fi
+
+        log_info "Cleaning Docker containers on local system"
+        if ! bash -c "$script"; then
+            log_error "Failed to clean docker containers locally"
+            exit 1
+        fi
+    fi
+}
+
+main "$@"

--- a/usr/local/bin/cmds/robot-setup
+++ b/usr/local/bin/cmds/robot-setup
@@ -165,19 +165,17 @@ setup_local() {
                     local current_user="${SUDO_USER:-$USER}"
                     local current_uid="$(id -u "$current_user")"
                     local current_gid="$(id -g "$current_user")"
+                    local current_group="$(id -gn "$current_user")"
 
                     log_info "Updating environment file to reflect the current user and paths..."
 
                     # Update variables in the environment file
                     sed -i "s|^USER_NAME=.*|USER_NAME=$current_user|g" "$env_file"
                     sed -i "s|^USER=.*|USER=$current_user|g" "$env_file"
-                    sed -i "s|^GROUP_NAME=.*|GROUP_NAME=$current_user|g" "$env_file"
+                    sed -i "s|^GROUP_NAME=.*|GROUP_NAME=$current_group|g" "$env_file"
                     sed -i "s|^USER_ID=.*|USER_ID=$current_uid|g" "$env_file"
                     sed -i "s|^GROUP_ID=.*|GROUP_ID=$current_gid|g" "$env_file"
                     sed -i "s|^AIRLAB_PATH=.*|AIRLAB_PATH=$airlab_path|g" "$env_file"
-                    sed -i "s|^DOCKER_BUILD_PATH=.*|DOCKER_BUILD_PATH=$airlab_path/docker/docker-compose.yml|g" "$env_file"
-                    sed -i "s|^DOCKER_UP_PATH=.*|DOCKER_UP_PATH=$airlab_path/docker/docker-compose.yml|g" "$env_file"
-                    sed -i "s|^LAUNCH_FILE_PATH=.*|LAUNCH_FILE_PATH=$airlab_path/launch/sample.yaml|g" "$env_file"
 
                     log_info "Environment file updated successfully."
                 else
@@ -451,23 +449,83 @@ setup_remote() {
 
     # Setup remote environment
     log_info "Setting up remote environment..."
+
+    # Robot gets a fresh clone of origin/main of the local $AIRLAB_PATH,
+    # not the host's working tree. Keeps fleet state canonical.
+    # All git ops run as $SUDO_USER: the local repo is owned by them (modern
+    # git refuses cross-user reads), and `git clone` over SSH needs their keys.
+    local -a as_user
+    if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+        as_user=(sudo -u "$SUDO_USER" --)
+    else
+        as_user=()
+    fi
+
+    local origin_url
+    origin_url=$("${as_user[@]}" git -C "$remote_path" remote get-url origin 2>/dev/null) \
+        || error_exit "$remote_path is not a git repo (or has no 'origin'); cannot resolve source for remote install"
+
+    log_info "Source: $origin_url (main)"
+    "${as_user[@]}" git -C "$remote_path" fetch --quiet origin main 2>/dev/null \
+        || log_warn "Could not fetch origin/main; comparison may be stale"
+
+    local ahead_commits dirty_files
+    ahead_commits=$("${as_user[@]}" git -C "$remote_path" log --oneline origin/main..HEAD 2>/dev/null)
+    dirty_files=$("${as_user[@]}" git -C "$remote_path" status -s 2>/dev/null)
+
+    if [[ -n "$ahead_commits" || -n "$dirty_files" ]]; then
+        log_warn "Local $remote_path differs from origin/main; the changes below will NOT land on the robot:"
+        if [[ -n "$ahead_commits" ]]; then
+            echo "  Commits ahead of origin/main:"
+            echo "$ahead_commits" | sed 's/^/    /'
+        fi
+        if [[ -n "$dirty_files" ]]; then
+            echo "  Uncommitted changes:"
+            echo "$dirty_files" | sed 's/^/    /'
+        fi
+        if [ "$force" = true ]; then
+            log_warn "Force flag set; proceeding with origin/main only."
+        else
+            read -p "Proceed with origin/main on the robot? (y/N): " confirm
+            [[ ! "$confirm" =~ ^[Yy]$ ]] && error_exit "Setup cancelled"
+        fi
+    fi
+
+    local clone_dir
+    clone_dir="$("${as_user[@]}" mktemp -d -t airlab-ws-clone.XXXXXX)"
+    if [ -z "$clone_dir" ] || [ ! -d "$clone_dir" ] || [ "$clone_dir" = "/" ] || [ "${clone_dir#/}" = "$clone_dir" ]; then
+        error_exit "Refusing to proceed: invalid clone tmp dir: '$clone_dir'"
+    fi
+    trap "rm -rf '$clone_dir'" EXIT
+    log_info "Cloning $origin_url (main) into $clone_dir/airlab_ws ..."
+    "${as_user[@]}" git clone --depth 1 --branch main "$origin_url" "$clone_dir/airlab_ws" \
+        || error_exit "Failed to clone $origin_url (main)"
+
     # Create directory structure
     remote_exec "$robot_ssh_address" "mkdir -p $airlab_path" "$robot_password"
 
     # Copy files
-    log_info "Copying configuration files..."
+    log_info "Copying configuration files to robot..."
     "${SSHPASS_PREFIX[@]}" rsync -avz --exclude='.git' \
-        "$remote_path/" "$robot_ssh_address:$airlab_path/" || error_exit "Failed to copy files"
+        "$clone_dir/airlab_ws/" "$robot_ssh_address:$airlab_path/" || error_exit "Failed to copy files"
+
+    # Resolve install source — recorded at .deb-build time so each fork's
+    # package fetches from its own repo without baking the URL into code.
+    local source_repo source_url
+    source_repo=$(cat /usr/share/airlab/install_source 2>/dev/null || echo "strapsai/airlab")
+    source_url="https://github.com/${source_repo}/archive/refs/heads/main.zip"
 
     # Install package if needed
     if ! "${SSHPASS_PREFIX[@]}" ssh -o StrictHostKeyChecking=no "$robot_ssh_address" "dpkg -l | grep -q '^ii.*airlab'" ; then
         log_info "Installing airlab package..."
-        sudo curl -L -o /tmp/airlab.zip https://github.com/kabirkedia/airlab/archive/refs/heads/main.zip
+        sudo curl -L -o /tmp/airlab.zip "$source_url"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S rm -rf /tmp/airlab-main /tmp/airlab-main.deb /tmp/airlab.zip" "$robot_password"
         remote_copy "/tmp/airlab.zip" "$robot_ssh_address:/tmp/airlab.zip" "$robot_password"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S unzip -o /tmp/airlab.zip -d /tmp/" "$robot_password"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S chmod a+x -R /tmp/airlab-main" "$robot_password"
-        remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S echo "HERE" && bash /tmp/airlab-main/install.sh" "$robot_password"
+        # ssh -tt: pty makes sudo's timestamp cache survive into install.sh's internal sudo calls. install.sh must run as user (not root) so its ~/VENVs and ~/.bashrc edits use the right $HOME.
+        "${SSHPASS_PREFIX[@]}" ssh -tt -o StrictHostKeyChecking=no "$robot_ssh_address" "echo '$robot_password' | sudo -S echo HERE && bash /tmp/airlab-main/install.sh" \
+            || error_exit "Failed to run install.sh on $robot_ssh_address"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S dpkg-deb --build /tmp/airlab-main" "$robot_password"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S dpkg -i /tmp/airlab-main.deb" "$robot_password" "warn"
         remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S apt-get install -f -y" "$robot_password"
@@ -478,13 +536,15 @@ setup_remote() {
             log_warn "Skipping installation"
         else
             log_info "Installing airlab package..."
-            sudo curl -L -o /tmp/airlab.zip https://github.com/kabirkedia/airlab/archive/refs/heads/main.zip
+            sudo curl -L -o /tmp/airlab.zip "$source_url"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S rm -rf /tmp/airlab-main /tmp/airlab-main.deb /tmp/airlab.zip" "$robot_password"
             remote_copy "/tmp/airlab.zip" "$robot_ssh_address:/tmp/airlab.zip" "$robot_password"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S unzip -o /tmp/airlab.zip -d /tmp/" "$robot_password"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S chmod a+x -R /tmp/airlab-main" "$robot_password"
-            remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S echo "HERE" && bash /tmp/airlab-main/install.sh" "$robot_password"
-            remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S dpkg-deb --build /tmp/airlab-main" "$robot_password" 
+            # ssh -tt: pty makes sudo's timestamp cache survive into install.sh's internal sudo calls. install.sh must run as user (not root) so its ~/VENVs and ~/.bashrc edits use the right $HOME.
+            "${SSHPASS_PREFIX[@]}" ssh -tt -o StrictHostKeyChecking=no "$robot_ssh_address" "echo '$robot_password' | sudo -S echo HERE && bash /tmp/airlab-main/install.sh" \
+                || error_exit "Failed to run install.sh on $robot_ssh_address"
+            remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S dpkg-deb --build /tmp/airlab-main" "$robot_password"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S dpkg -i /tmp/airlab-main.deb" "$robot_password" "warn"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S apt-get install -f -y" "$robot_password"
             remote_exec "$robot_ssh_address" "echo '$robot_password' | sudo -S rm -rf /tmp/airlab-main /tmp/airlab-main.deb /tmp/airlab.zip" "$robot_password"

--- a/usr/local/bin/cmds/set_hosts
+++ b/usr/local/bin/cmds/set_hosts
@@ -1,0 +1,444 @@
+#!/bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -euo pipefail
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+readonly HOSTS_FILE="/etc/hosts"
+readonly START_MARKER="# Airlab Hosts Start"
+readonly END_MARKER="# Airlab Hosts End"
+
+# Logging functions
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+show_usage() {
+    cat << EOF
+Usage: airlab set_hosts <target> [options]
+
+Update /etc/hosts with hostname-to-IP mappings from robot.conf.
+
+Arguments:
+    <target>        'local' to update the local /etc/hosts file, or a robot
+                    name (from robot.conf) to update the remote robot's
+                    /etc/hosts file via SSH.
+
+Options:
+    --password      Skip key-based SSH and prompt for password directly
+                    (remote targets only)
+    --help          Show this help message
+
+Details:
+    Reads robot.conf entries (e.g. mt001=dtc@10.223.1.99) and generates
+    /etc/hosts entries so that robot names resolve to their IP addresses.
+    Entries using ssh:// URIs (port-forwarded connections) are skipped.
+
+    A timestamped backup of /etc/hosts is created before any modification
+    (e.g. /etc/hosts_20260429_160345).
+
+    Entries are placed between markers:
+        $START_MARKER
+        ...
+        $END_MARKER
+
+    If the markers already exist, only the content between them is replaced.
+    If they don't exist, a new section is appended.
+
+    Before writing, the command checks for hostname or IP conflicts with
+    existing /etc/hosts entries outside the markers. If conflicts are found,
+    the command warns and aborts.
+
+Examples:
+    airlab set_hosts local              # Update local /etc/hosts
+    airlab set_hosts mt001              # Update /etc/hosts on mt001
+    airlab set_hosts mt001 --password   # Use password authentication
+EOF
+}
+
+# Function to check if required commands exist
+check_dependencies() {
+    local deps=("ssh" "sudo")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+}
+
+parse_yaml() {
+    local yaml_file=$1
+    local key=$2
+    local result
+
+    if [[ ! -f "$yaml_file" ]]; then
+        log_error "YAML file not found: $yaml_file"
+        return 1
+    fi
+
+    if ! python3 -c "import yaml" 2>/dev/null; then
+        log_error "Python YAML module not found. Please install: pip3 install PyYAML"
+        return 1
+    fi
+
+    result=$(python3 -c '
+import sys
+import yaml
+
+try:
+    with open("'"$yaml_file"'", "r") as f:
+        data = yaml.safe_load(f)
+        value = data
+        for key in "'"$key"'".split("."):
+            if not isinstance(value, dict):
+                print("")
+                sys.exit(1)
+            value = value.get(key, "")
+        print(value)
+except Exception as e:
+    print("")
+    sys.exit(1)
+')
+
+    if [[ -z "$result" ]]; then
+        log_error "Failed to parse key '$key' from YAML file"
+        return 1
+    fi
+
+    echo "$result"
+}
+
+ssh_authenticate() {
+    local ssh_address=$1
+    local force_password=${2:-false}
+    robot_password=""
+
+    if [[ "$force_password" == false ]]; then
+        log_info "Attempting key-based SSH to $ssh_address..."
+        if ssh -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o BatchMode=yes "$ssh_address" exit 2>/dev/null; then
+            log_info "Key-based SSH connection successful"
+            return 0
+        fi
+        log_warn "Key-based SSH failed. Falling back to password authentication."
+    fi
+
+    if ! command -v sshpass >/dev/null 2>&1; then
+        log_error "Key-based SSH failed and 'sshpass' is not installed for password fallback."
+        log_error "Either set up SSH keys or install sshpass: sudo apt install sshpass"
+        return 1
+    fi
+
+    log_info "Enter password for $ssh_address:"
+    read -s robot_password
+    [[ -z "$robot_password" ]] && log_error "Password cannot be empty" && return 1
+    echo
+
+    if ! sshpass -p "$robot_password" ssh -o ConnectTimeout=15 -o StrictHostKeyChecking=no "$ssh_address" exit; then
+        log_error "Cannot connect to remote system '$ssh_address'"
+        return 1
+    fi
+    log_info "SSH connection successful"
+    return 0
+}
+
+# Parse robot.conf and generate /etc/hosts entries.
+# Output: one line per robot in the format "IP    hostname"
+# Skips ssh:// URI entries (port-forwarded connections) since they share
+# a single hostname with different ports and don't map to unique IPs.
+generate_hosts_entries() {
+    local conf_file="$1"
+    local entries=""
+    local skipped=()
+
+    while IFS='=' read -r name value; do
+        # Skip empty lines, comments, or lines without '='
+        [[ -z "$name" || -z "$value" || "$name" == \#* ]] && continue
+
+        # Skip ssh:// URI entries (port-forwarded connections)
+        if [[ "$value" == ssh://* ]]; then
+            skipped+=("$name")
+            continue
+        fi
+
+        local ip
+        ip=$(echo "$value" | cut -d'@' -f2)
+
+        # Handle addresses with port (user@host:port)
+        ip=$(echo "$ip" | cut -d':' -f1)
+
+        if [[ -n "$ip" && -n "$name" ]]; then
+            entries+="$(printf "%-15s %s" "$ip" "$name")"$'\n'
+        fi
+    done < "$conf_file"
+
+    if [[ ${#skipped[@]} -gt 0 ]]; then
+        log_info "Skipped ${#skipped[@]} ssh:// port-forwarded entries: ${skipped[*]}" >&2
+    fi
+
+    # Remove trailing newline
+    echo -n "$entries"
+}
+
+# Check for conflicts between new entries and existing /etc/hosts content
+# (outside the airlab markers). Returns 0 if clean, 1 if conflicts found.
+# $1 = hosts file content, $2 = new entries to add
+check_conflicts() {
+    local hosts_content="$1"
+    local new_entries="$2"
+    local has_conflict=false
+
+    # Extract lines outside the airlab marker block (skip comments and blanks)
+    local outside_lines
+    outside_lines=$(echo "$hosts_content" | awk \
+        -v start="$START_MARKER" -v end="$END_MARKER" '
+        $0 == start { in_block = 1; next }
+        $0 == end   { in_block = 0; next }
+        !in_block   { print }
+    ' | grep -v '^\s*#' | grep -v '^\s*$' || true)
+
+    # Check each new entry against existing entries
+    while IFS= read -r new_line; do
+        [[ -z "$new_line" ]] && continue
+
+        local new_ip new_hostname
+        new_ip=$(echo "$new_line" | awk '{print $1}')
+        new_hostname=$(echo "$new_line" | awk '{print $2}')
+
+        # Check for duplicate hostname
+        local existing_ip
+        existing_ip=$(echo "$outside_lines" | awk -v h="$new_hostname" '
+            { for (i=2; i<=NF; i++) if ($i == h) print $1 }
+        ' | head -1)
+
+        if [[ -n "$existing_ip" ]]; then
+            if [[ "$existing_ip" == "$new_ip" ]]; then
+                log_warn "Hostname '$new_hostname' already mapped to $new_ip outside airlab markers (duplicate)"
+            else
+                log_error "CONFLICT: Hostname '$new_hostname' is already mapped to $existing_ip outside airlab markers (new: $new_ip)"
+            fi
+            has_conflict=true
+        fi
+
+        # Check for duplicate IP with different hostname
+        local existing_hostnames
+        existing_hostnames=$(echo "$outside_lines" | awk -v ip="$new_ip" '
+            $1 == ip { for (i=2; i<=NF; i++) print $i }
+        ' || true)
+
+        if [[ -n "$existing_hostnames" ]]; then
+            while IFS= read -r eh; do
+                if [[ "$eh" != "$new_hostname" ]]; then
+                    log_warn "IP $new_ip is already mapped to hostname '$eh' outside airlab markers"
+                fi
+            done <<< "$existing_hostnames"
+        fi
+    done <<< "$new_entries"
+
+    if [[ "$has_conflict" == true ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Build the new /etc/hosts content with entries inserted between markers.
+# $1 = current hosts file content, $2 = new entries
+build_new_hosts() {
+    local hosts_content="$1"
+    local new_entries="$2"
+
+    if echo "$hosts_content" | grep -q "^${START_MARKER}$"; then
+        # Markers exist: replace content between them
+        echo "$hosts_content" | awk \
+            -v start="$START_MARKER" -v end="$END_MARKER" -v content="$new_entries" '
+            $0 == start { print; print content; skip = 1; next }
+            $0 == end   { print; skip = 0; next }
+            !skip       { print }
+        '
+    else
+        # No markers: append new section
+        echo "$hosts_content"
+        echo ""
+        echo "$START_MARKER"
+        echo "$new_entries"
+        echo "$END_MARKER"
+    fi
+}
+
+# Update /etc/hosts on the local machine
+set_local_hosts() {
+    local new_entries="$1"
+
+    if [[ ! -f "$HOSTS_FILE" ]]; then
+        log_error "$HOSTS_FILE not found"
+        exit 1
+    fi
+
+    local hosts_content
+    hosts_content=$(cat "$HOSTS_FILE")
+
+    # Check for conflicts
+    log_info "Checking for conflicts with existing entries..."
+    if ! check_conflicts "$hosts_content" "$new_entries"; then
+        log_error "Conflicts detected. Resolve them manually before proceeding."
+        exit 1
+    fi
+    log_info "No conflicts found."
+
+    # Build new content
+    local new_hosts
+    new_hosts=$(build_new_hosts "$hosts_content" "$new_entries")
+
+    # Show what will change
+    echo ""
+    log_info "The following entries will be set between airlab markers:"
+    echo "$new_entries" | sed 's/^/    /'
+    echo ""
+
+    # Create timestamped backup
+    local backup_suffix
+    backup_suffix=$(date +"%Y%m%d_%H%M%S")
+    local backup_path="${HOSTS_FILE}_${backup_suffix}"
+    log_info "Creating backup: $backup_path"
+    sudo cp "$HOSTS_FILE" "$backup_path"
+
+    # Write the updated hosts file
+    echo "$new_hosts" | sudo tee "$HOSTS_FILE" > /dev/null
+    log_info "Local $HOSTS_FILE updated successfully."
+}
+
+# Update /etc/hosts on a remote machine via SSH
+set_remote_hosts() {
+    local ssh_address="$1"
+    local new_entries="$2"
+
+    # Read remote /etc/hosts
+    local hosts_content
+    hosts_content=$("${SSHPASS_PREFIX[@]}" ssh -o StrictHostKeyChecking=no "$ssh_address" "cat $HOSTS_FILE") || {
+        log_error "Failed to read $HOSTS_FILE on $ssh_address"
+        exit 1
+    }
+
+    # Check for conflicts
+    log_info "Checking for conflicts on remote $ssh_address..."
+    if ! check_conflicts "$hosts_content" "$new_entries"; then
+        log_error "Conflicts detected on remote system. Resolve them manually before proceeding."
+        exit 1
+    fi
+    log_info "No conflicts found."
+
+    # Build new content
+    local new_hosts
+    new_hosts=$(build_new_hosts "$hosts_content" "$new_entries")
+
+    # Show what will change
+    echo ""
+    log_info "The following entries will be set between airlab markers on $ssh_address:"
+    echo "$new_entries" | sed 's/^/    /'
+    echo ""
+
+    # Create timestamped backup on remote
+    local backup_suffix
+    backup_suffix=$(date +"%Y%m%d_%H%M%S")
+    local backup_path="${HOSTS_FILE}_${backup_suffix}"
+    log_info "Creating remote backup: $backup_path"
+    "${SSHPASS_PREFIX[@]}" ssh -o StrictHostKeyChecking=no "$ssh_address" \
+        "sudo cp $HOSTS_FILE $backup_path" || {
+        log_error "Failed to create backup on $ssh_address"
+        exit 1
+    }
+
+    # Write the updated hosts file on remote
+    echo "$new_hosts" | "${SSHPASS_PREFIX[@]}" ssh -o StrictHostKeyChecking=no "$ssh_address" \
+        "sudo tee $HOSTS_FILE > /dev/null" || {
+        log_error "Failed to update $HOSTS_FILE on $ssh_address"
+        exit 1
+    }
+    log_info "Remote $HOSTS_FILE on $ssh_address updated successfully."
+}
+
+main() {
+    check_dependencies
+
+    if [[ $# -eq 0 || "$1" == "--help" ]]; then
+        show_usage
+        exit 0
+    fi
+
+    local target="$1"
+    shift
+
+    local FORCE_PASSWORD=false
+
+    # Parse additional flags
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --password)
+                FORCE_PASSWORD=true
+                ;;
+            --help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                log_error "Invalid option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    # Load robot.conf
+    local ROBOT_CONF="$AIRLAB_PATH/robot/robot.conf"
+    if [[ ! -f "$ROBOT_CONF" ]]; then
+        log_error "Robot configuration file not found at '$ROBOT_CONF'"
+        exit 1
+    fi
+    log_info "Using robot configuration: $(realpath "$ROBOT_CONF")"
+
+    # Generate hosts entries from robot.conf
+    local new_entries
+    new_entries=$(generate_hosts_entries "$ROBOT_CONF")
+    if [[ -z "$new_entries" ]]; then
+        log_error "No entries found in $ROBOT_CONF"
+        exit 1
+    fi
+
+    case "$target" in
+        local)
+            set_local_hosts "$new_entries"
+            ;;
+        *)
+            # Treat as a robot name — look up SSH address
+            set +e
+            local ROBOT_SSH_ADDRESS
+            ROBOT_SSH_ADDRESS=$(grep "^${target}=" "$ROBOT_CONF" | cut -d= -f2)
+            if [[ -z "$ROBOT_SSH_ADDRESS" ]]; then
+                log_error "Robot '$target' not found in $ROBOT_CONF"
+                exit 1
+            fi
+            set -e
+
+            # Authenticate via SSH
+            robot_password=""
+            if ! ssh_authenticate "$ROBOT_SSH_ADDRESS" "$FORCE_PASSWORD"; then
+                exit 1
+            fi
+
+            SSHPASS_PREFIX=()
+            if [[ -n "$robot_password" ]]; then
+                SSHPASS_PREFIX=(sshpass -p "$robot_password")
+            fi
+
+            set_remote_hosts "$ROBOT_SSH_ADDRESS" "$new_entries"
+            ;;
+    esac
+}
+
+main "$@"

--- a/usr/local/bin/cmds/version-control/check
+++ b/usr/local/bin/cmds/version-control/check
@@ -1,0 +1,454 @@
+#!/bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -uo pipefail
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Logging functions
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+show_usage() {
+    cat << EOF
+Usage: airlab vcs check [OPTIONS]
+
+Check for repository drift in two complementary ways.
+
+Modes:
+  (default)              Walk the current directory recursively, find git
+                         repositories (skipping submodules), group them by
+                         remote URL, and flag any group whose clones are not
+                         all on the same commit. Run this from \$AIRLAB_PATH
+                         before tagging shared workspaces.
+  --version-control      Ignore the current directory; instead read every
+                         YAML file under \$AIRLAB_PATH/version_control/. Flag
+                         any URL pinned to multiple 'version:' values across
+                         YAMLs, and any duplicate URLs within a single YAML.
+
+Options:
+  --no-progress          Disable the progress bar (also auto-disabled when
+                         stderr is not a terminal).
+  --help                 Show this help message and exit.
+
+Exit codes:
+  0  No drift / no duplicates found.
+  1  Drift, duplicate URLs, or YAML parse errors detected.
+
+Examples:
+  airlab cd && airlab vcs check
+  airlab vcs check --version-control
+
+Note: Submodules (where '.git' is a file or 'git rev-parse
+--show-superproject-working-tree' returns non-empty) are skipped because
+they are managed by their parent repository.
+EOF
+}
+
+check_dependencies() {
+    local deps=("git")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+    if ! python3 -c "import yaml" 2>/dev/null; then
+        log_error "Python YAML module not found. Please install: pip3 install PyYAML"
+        exit 1
+    fi
+}
+
+check_filesystem() {
+    local base_dir=$1
+    local progress=$2
+
+    python3 - "$base_dir" "$progress" <<'PYEOF'
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+GREEN  = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+NC     = "\033[0m"
+
+base_dir       = os.path.abspath(sys.argv[1])
+progress_flag  = sys.argv[2]   # "off" if user passed --no-progress
+show_progress  = (progress_flag != "off") and sys.stderr.isatty()
+
+# --- Progress bar plumbing -------------------------------------------------
+# Renders to stderr only on a TTY. We throttle redraws to ~25 fps so a fast
+# pass over hundreds of small repos does not spam the terminal.
+_last_render = [0.0]
+
+def _term_width():
+    try:
+        return shutil.get_terminal_size((80, 20)).columns
+    except Exception:
+        return 80
+
+def progress_line(label, i, total, item, force=False):
+    if not show_progress:
+        return
+    now = time.monotonic()
+    if not force and (now - _last_render[0]) < 0.04:
+        return
+    _last_render[0] = now
+    width = _term_width()
+    bar_w = 20
+    pct   = (i / total) if total else 1.0
+    fill  = int(bar_w * pct)
+    bar   = "█" * fill + "░" * (bar_w - fill)
+    head  = f"[{bar}] {i}/{total}  {label}: "
+    space = max(0, width - len(head) - 1)
+    if len(item) > space:
+        item = "…" + item[-(space - 1):] if space > 1 else ""
+    line = head + item
+    # Pad to terminal width so leftover characters from longer previous
+    # lines do not linger after a shorter one.
+    pad = max(0, width - len(line) - 1)
+    sys.stderr.write("\r" + line + (" " * pad))
+    sys.stderr.flush()
+
+def progress_clear():
+    if not show_progress:
+        return
+    width = _term_width()
+    sys.stderr.write("\r" + (" " * (width - 1)) + "\r")
+    sys.stderr.flush()
+
+def git(repo_dir, *args, timeout=10):
+    result = subprocess.run(
+        ["git", "-C", repo_dir] + list(args),
+        capture_output=True, text=True, timeout=timeout
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+def normalize_url(url):
+    """Normalize git URLs so equivalent ssh/https forms group together."""
+    if not url:
+        return None
+    url = url.strip()
+    if url.endswith('.git'):
+        url = url[:-4]
+    # Match git@host:owner/repo, ssh://[git@]host[:port]/owner/repo,
+    # https?://host/owner/repo. Capture host + path.
+    m = re.match(r'^(?:git@|ssh://(?:git@)?|https?://)([^/:]+)(?::\d+)?[:/](.+)$', url)
+    if m:
+        host, path = m.groups()
+        return f"{host.lower()}/{path}"
+    return url
+
+# --- Walk PWD, collecting git repos and skipping submodules ---
+#
+# A repo whose '.git' is a directory is included AND we keep descending into
+# its subdirectories — this is the airlab_ws case, where the meta-repo
+# contains many vcstool-cloned sub-repos as plain folders. A repo whose
+# '.git' is a file is treated as a submodule (or linked worktree) and the
+# entire subtree is skipped, since submodules are managed by their parent.
+repos = []
+def walk(path):
+    git_path = os.path.join(path, '.git')
+    if os.path.isdir(git_path):
+        rc, out, _ = git(path, 'rev-parse', '--show-superproject-working-tree')
+        if rc == 0 and out:
+            return  # submodule, skip subtree entirely
+        repos.append(path)
+        # Indeterminate-total bar during the walk: shows count + the most
+        # recent path scanned, so the user sees activity even before we
+        # know the final repo count.
+        progress_line("scanning", len(repos), max(len(repos), 1),
+                      os.path.relpath(path, base_dir))
+    elif os.path.isfile(git_path):
+        return  # submodule or linked worktree, skip subtree
+    try:
+        entries = sorted(os.listdir(path))
+    except (PermissionError, OSError):
+        return
+    for entry in entries:
+        if entry == '.git' or entry.startswith('.'):
+            continue
+        full = os.path.join(path, entry)
+        if os.path.isdir(full) and not os.path.islink(full):
+            walk(full)
+
+walk(base_dir)
+progress_clear()
+
+if not repos:
+    print(f"{YELLOW}[INFO]{NC} No git repositories found under {base_dir}")
+    sys.exit(0)
+
+# --- Collect per-repo info ---
+infos = []
+total = len(repos)
+for idx, repo in enumerate(repos, start=1):
+    rel = os.path.relpath(repo, base_dir)
+    progress_line("inspecting", idx, total, rel)
+    rc, url, _   = git(repo, 'config', '--get', 'remote.origin.url')
+    rc2, sha, _  = git(repo, 'rev-parse', 'HEAD')
+    rc3, br, _   = git(repo, 'rev-parse', '--abbrev-ref', 'HEAD')
+    rc4, st, _   = git(repo, 'status', '--porcelain')
+    infos.append({
+        'rel':    rel,
+        'url':    url if rc == 0 and url else None,
+        'norm':   normalize_url(url) if rc == 0 else None,
+        'sha':    sha if rc2 == 0 and sha else None,
+        'branch': br if rc3 == 0 and br else None,
+        'dirty':  bool(st),
+    })
+
+progress_clear()
+
+# --- Group by normalized URL ---
+groups = defaultdict(list)
+no_origin = []
+for info in infos:
+    if info['norm']:
+        groups[info['norm']].append(info)
+    else:
+        no_origin.append(info)
+
+shared_groups = {url: g for url, g in groups.items() if len(g) > 1}
+
+# --- Header summary ---
+print(f"Scanned {len(infos)} git repositor{'y' if len(infos) == 1 else 'ies'} under {base_dir}")
+print(f"  - {len(groups)} unique remote URL(s)")
+print(f"  - {len(shared_groups)} URL(s) with multiple clones")
+if no_origin:
+    print(f"  - {len(no_origin)} repositor{'y' if len(no_origin) == 1 else 'ies'} without an origin remote")
+print()
+
+# --- Drift analysis ---
+drift_groups = []
+warn_groups  = []
+ok_groups    = []
+for url, group in shared_groups.items():
+    shas     = {g['sha']    for g in group if g['sha']}
+    branches = {g['branch'] for g in group if g['branch']}
+    if len(shas) > 1:
+        drift_groups.append((url, group, shas))
+    elif len(branches) > 1:
+        warn_groups.append((url, group, branches))
+    else:
+        ok_groups.append((url, group))
+
+dirty_repos = [info for info in infos if info['dirty']]
+
+if drift_groups:
+    print(f"{RED}[DRIFT]{NC} {len(drift_groups)} shared repositor{'y' if len(drift_groups) == 1 else 'ies'} on different commits:")
+    for url, group, _shas in sorted(drift_groups):
+        print(f"  {RED}✗{NC} {url}")
+        for g in sorted(group, key=lambda x: x['rel']):
+            short = (g['sha'] or '?')[:8]
+            br    = g['branch'] or '?'
+            tag   = f" {YELLOW}(dirty){NC}" if g['dirty'] else ""
+            print(f"      {short}  on {br:<24s}  {g['rel']}{tag}")
+    print()
+
+if warn_groups:
+    print(f"{YELLOW}[BRANCH SKEW]{NC} {len(warn_groups)} shared repositor{'y' if len(warn_groups) == 1 else 'ies'} at the same commit but on different branches:")
+    for url, group, _branches in sorted(warn_groups):
+        print(f"  {YELLOW}!{NC} {url}")
+        for g in sorted(group, key=lambda x: x['rel']):
+            br    = g['branch'] or '?'
+            tag   = f" {YELLOW}(dirty){NC}" if g['dirty'] else ""
+            print(f"      on {br:<24s}  {g['rel']}{tag}")
+    print()
+
+if ok_groups:
+    print(f"{GREEN}[OK]{NC} {len(ok_groups)} shared repositor{'y' if len(ok_groups) == 1 else 'ies'} all on the same commit.")
+
+if no_origin:
+    print()
+    print(f"{YELLOW}[NO ORIGIN]{NC} {len(no_origin)} repositor{'y' if len(no_origin) == 1 else 'ies'} without an origin remote (excluded from grouping):")
+    for info in sorted(no_origin, key=lambda x: x['rel']):
+        print(f"      {info['rel']}")
+
+if dirty_repos:
+    print()
+    print(f"{YELLOW}[DIRTY]{NC} {len(dirty_repos)} repositor{'y' if len(dirty_repos) == 1 else 'ies'} with uncommitted changes:")
+    for info in sorted(dirty_repos, key=lambda x: x['rel']):
+        print(f"      {info['rel']}")
+
+if drift_groups:
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+check_version_control() {
+    local airlab_path=$1
+    local vc_dir="$airlab_path/version_control"
+    if [[ ! -d "$vc_dir" ]]; then
+        log_error "version_control directory not found: $vc_dir"
+        return 1
+    fi
+
+    python3 - "$vc_dir" <<'PYEOF'
+import os
+import re
+import sys
+import yaml
+from collections import defaultdict
+
+GREEN  = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+NC     = "\033[0m"
+
+vc_dir = sys.argv[1]
+
+def normalize_url(url):
+    if not url:
+        return None
+    url = url.strip()
+    if url.endswith('.git'):
+        url = url[:-4]
+    m = re.match(r'^(?:git@|ssh://(?:git@)?|https?://)([^/:]+)(?::\d+)?[:/](.+)$', url)
+    if m:
+        host, path = m.groups()
+        return f"{host.lower()}/{path}"
+    return url
+
+yaml_files = sorted(f for f in os.listdir(vc_dir) if f.endswith('.yaml') or f.endswith('.yml'))
+if not yaml_files:
+    print(f"{YELLOW}[INFO]{NC} No YAML files found in {vc_dir}")
+    sys.exit(0)
+
+# inter:    norm_url -> [(yaml_file, name, version)]
+# intra:    yaml_file -> norm_url -> [name, ...]
+inter = defaultdict(list)
+intra = defaultdict(lambda: defaultdict(list))
+parse_errors = []
+
+for yf in yaml_files:
+    path = os.path.join(vc_dir, yf)
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as e:
+        parse_errors.append((yf, str(e)))
+        continue
+    repos = data.get('repositories') or {}
+    if not isinstance(repos, dict):
+        continue
+    for name, info in repos.items():
+        if not isinstance(info, dict):
+            continue
+        if info.get('type') != 'git':
+            continue
+        url = info.get('url')
+        ver = info.get('version', '<unspecified>')
+        if not url:
+            continue
+        norm = normalize_url(url)
+        if norm is None:
+            continue
+        inter[norm].append((yf, name, str(ver)))
+        intra[yf][norm].append(name)
+
+total_refs = sum(len(v) for v in inter.values())
+print(f"Scanned {len(yaml_files)} YAML file(s) in {vc_dir}")
+print(f"  - {len(inter)} distinct git remote URL(s)")
+print(f"  - {total_refs} total git repository reference(s)")
+if parse_errors:
+    print(f"  - {RED}{len(parse_errors)} YAML file(s) failed to parse{NC}")
+print()
+
+if parse_errors:
+    print(f"{RED}[PARSE ERROR]{NC} Could not load {len(parse_errors)} file(s):")
+    for yf, err in parse_errors:
+        print(f"  {RED}✗{NC} {yf}: {err}")
+    print()
+
+# --- Inter-YAML version drift ---
+drift = {url: refs for url, refs in inter.items()
+         if len({r[2] for r in refs}) > 1}
+if drift:
+    print(f"{RED}[VERSION DRIFT]{NC} {len(drift)} URL(s) pinned to multiple 'version' values across YAMLs:")
+    for url, refs in sorted(drift.items()):
+        by_ver = defaultdict(list)
+        for yf, name, ver in refs:
+            by_ver[ver].append((yf, name))
+        print(f"  {RED}✗{NC} {url}")
+        for ver in sorted(by_ver):
+            print(f"      version: {ver}")
+            for yf, name in sorted(by_ver[ver]):
+                print(f"        - {yf} :: {name}")
+else:
+    print(f"{GREEN}[OK]{NC} No cross-YAML version drift detected.")
+
+# --- Intra-YAML duplicate URLs ---
+print()
+intra_dupes = []
+for yf in sorted(intra):
+    for url, names in intra[yf].items():
+        if len(names) > 1:
+            intra_dupes.append((yf, url, names))
+
+if intra_dupes:
+    print(f"{RED}[DUPLICATE URL]{NC} {len(intra_dupes)} duplicate-URL case(s) within single YAMLs:")
+    for yf, url, names in intra_dupes:
+        print(f"  {RED}✗{NC} {yf}: {url}")
+        for n in sorted(names):
+            print(f"        - {n}")
+else:
+    print(f"{GREEN}[OK]{NC} No duplicate URLs within any single YAML.")
+
+if drift or intra_dupes or parse_errors:
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+main() {
+    check_dependencies
+
+    local mode="filesystem"
+    local progress="on"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version-control)
+                mode="version-control"
+                ;;
+            --no-progress)
+                progress="off"
+                ;;
+            --help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                log_error "Invalid option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    if [[ "$mode" == "version-control" ]]; then
+        if [[ -z "${AIRLAB_PATH:-}" ]]; then
+            log_error "AIRLAB_PATH is not set. Run 'airlab setup local' first."
+            exit 1
+        fi
+        check_version_control "$AIRLAB_PATH"
+    else
+        check_filesystem "$PWD" "$progress"
+    fi
+}
+
+# Run main function
+main "$@"

--- a/usr/local/bin/cmds/version-control/checkout
+++ b/usr/local/bin/cmds/version-control/checkout
@@ -1,0 +1,425 @@
+#!/bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -uo pipefail
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Logging functions
+log_info()  { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+show_usage() {
+    cat << EOF
+Usage: airlab vcs checkout <ref> [OPTIONS]
+
+Recursively run \`git checkout <ref>\` in every repository under the
+current directory, skipping submodules. <ref> may be a branch or tag.
+
+After each checkout, the post-state is summarized in a colored table:
+the new branch (or tag), ahead/behind upstream where applicable, and
+whether submodule SHAs changed.
+
+Arguments:
+  <ref>                  Branch or tag name to check out.
+
+Options:
+  --no-fetch             Skip \`git fetch --tags origin\` before
+                         checkout. Faster, but tag availability and
+                         ahead/behind counts may be stale.
+  --force, -f            Pass -f to \`git checkout\`, discarding local
+                         uncommitted changes. Use with care.
+  --no-progress          Disable the progress bar (also auto-disabled
+                         when stderr is not a terminal).
+  --help                 Show this help message and exit.
+
+Behavior:
+  1. Walk PWD with the same logic as \`airlab vcs check\` (skip
+     submodules and linked worktrees, descend through repos).
+  2. For each repo: \`git fetch --quiet --tags origin\` unless
+     --no-fetch is set.
+  3. For each repo: \`git checkout <ref>\` (or \`-f\` with --force).
+     - If <ref> is a branch on origin but not yet local, git's DWIM
+       creates a tracking branch automatically.
+     - If <ref> is a tag, the result is a detached HEAD.
+     - If <ref> does not exist on the repo (not a local branch, not
+       a tag, not origin/<ref>), report 'ref MISSING' and skip.
+     - If the working tree is dirty and checkout would overwrite,
+       report 'FAILED (dirty)' and skip (--force overrides).
+  4. After a successful checkout, classify the repo:
+     - On a branch with upstream: compute ahead/behind (\`+N\`/\`-N\`).
+     - On a tag (detached): no remote comparison.
+     - Submodule SHAs are snapshotted before and after; any change
+       in the recorded SHA of any submodule is reported.
+
+Output:
+  Per-repo row colored by status:
+    green   ok            — checked out, on ref, up to date.
+    yellow  warn          — checked out but ahead/behind upstream,
+                            or submodule SHAs changed.
+    red     err           — ref MISSING, FAILED, FAILED (dirty), or
+                            fetch failure.
+
+Exit codes:
+  0  All repos checked out cleanly and are up to date.
+  1  Any repo has a warn or err status.
+
+Examples:
+  airlab vcs checkout main
+  airlab vcs checkout v1.0.0
+  airlab vcs checkout strapsai/main --no-fetch
+  airlab vcs checkout main --force
+EOF
+}
+
+check_dependencies() {
+    local deps=("git")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+}
+
+do_checkout() {
+    local base_dir=$1
+    local ref=$2
+    local fetch=$3
+    local force=$4
+    local progress=$5
+
+    python3 - "$base_dir" "$ref" "$fetch" "$force" "$progress" <<'PYEOF'
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+GREEN  = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+NC     = "\033[0m"
+
+base_dir       = os.path.abspath(sys.argv[1])
+ref            = sys.argv[2]
+do_fetch       = sys.argv[3] == "1"
+force          = sys.argv[4] == "1"
+progress_flag  = sys.argv[5]
+show_progress  = (progress_flag != "off") and sys.stderr.isatty()
+
+# --- Progress bar plumbing (same shape as vcs check / vcs tag) -------------
+_last_render = [0.0]
+
+def _term_width():
+    try:
+        return shutil.get_terminal_size((80, 20)).columns
+    except Exception:
+        return 80
+
+def progress_line(label, i, total, item, force_render=False):
+    if not show_progress:
+        return
+    now = time.monotonic()
+    if not force_render and (now - _last_render[0]) < 0.04:
+        return
+    _last_render[0] = now
+    width = _term_width()
+    bar_w = 20
+    pct   = (i / total) if total else 1.0
+    fill  = int(bar_w * pct)
+    bar   = "█" * fill + "░" * (bar_w - fill)
+    head  = f"[{bar}] {i}/{total}  {label}: "
+    space = max(0, width - len(head) - 1)
+    if len(item) > space:
+        item = "…" + item[-(space - 1):] if space > 1 else ""
+    line = head + item
+    pad = max(0, width - len(line) - 1)
+    sys.stderr.write("\r" + line + (" " * pad))
+    sys.stderr.flush()
+
+def progress_clear():
+    if not show_progress:
+        return
+    width = _term_width()
+    sys.stderr.write("\r" + (" " * (width - 1)) + "\r")
+    sys.stderr.flush()
+
+def git(repo_dir, *args, timeout=60):
+    result = subprocess.run(
+        ["git", "-C", repo_dir] + list(args),
+        capture_output=True, text=True, timeout=timeout
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+# --- Walk PWD, same rules as vcs check -------------------------------------
+repos = []
+def walk(path):
+    git_path = os.path.join(path, '.git')
+    if os.path.isdir(git_path):
+        rc, out, _ = git(path, 'rev-parse', '--show-superproject-working-tree')
+        if rc == 0 and out:
+            return  # submodule subtree — managed by parent
+        repos.append(path)
+        progress_line("scanning", len(repos), max(len(repos), 1),
+                      os.path.relpath(path, base_dir))
+    elif os.path.isfile(git_path):
+        return  # submodule or linked worktree
+    try:
+        entries = sorted(os.listdir(path))
+    except (PermissionError, OSError):
+        return
+    for entry in entries:
+        if entry == '.git' or entry.startswith('.'):
+            continue
+        full = os.path.join(path, entry)
+        if os.path.isdir(full) and not os.path.islink(full):
+            walk(full)
+
+walk(base_dir)
+progress_clear()
+
+if not repos:
+    print(f"{YELLOW}[INFO]{NC} No git repositories found under {base_dir}")
+    sys.exit(0)
+
+print(f"Scanned {len(repos)} git repositor{'y' if len(repos) == 1 else 'ies'} under {base_dir}")
+print(f"  - target ref:    {ref}")
+print(f"  - fetch first:   {'yes' if do_fetch else 'no'}")
+print(f"  - force checkout:{' yes' if force else ' no'}")
+print()
+
+def submodule_sha_map(repo):
+    """Map of submodule_path -> recorded SHA (prefix stripped)."""
+    rc, out, _ = git(repo, 'submodule', 'status', '--recursive')
+    if rc != 0:
+        return {}
+    out_map = {}
+    for line in out.splitlines():
+        if not line:
+            continue
+        # git submodule status lines: "[+-U ]<sha> <path> [(describe)]"
+        s = line[1:] if line[0] in '+-U ' else line
+        s = s.lstrip()
+        parts = s.split(None, 2)
+        if len(parts) >= 2:
+            out_map[parts[1]] = parts[0]
+    return out_map
+
+def classify_ref(repo):
+    """Return (local_branch, is_tag, remote_branch) bools for `ref`."""
+    rc1, _, _ = git(repo, 'rev-parse', '--verify', '--quiet', f'refs/heads/{ref}')
+    rc2, _, _ = git(repo, 'rev-parse', '--verify', '--quiet', f'refs/tags/{ref}')
+    rc3, _, _ = git(repo, 'rev-parse', '--verify', '--quiet', f'refs/remotes/origin/{ref}')
+    return (rc1 == 0, rc2 == 0, rc3 == 0)
+
+results = []
+total = len(repos)
+
+for idx, repo in enumerate(repos, start=1):
+    rel = os.path.relpath(repo, base_dir)
+    progress_line("checking out", idx, total, rel, force_render=True)
+
+    r = {
+        'rel': rel,
+        'action': '',
+        'branch': '',
+        'remote': '',
+        'submod': '',
+        'status': 'ok',  # ok | warn | err
+    }
+
+    if do_fetch:
+        fc, _, _ = git(repo, 'fetch', '--quiet', '--tags', 'origin')
+        if fc != 0:
+            r['action'] = 'fetch FAILED'
+            r['status'] = 'err'
+            r['branch'] = r['remote'] = r['submod'] = '—'
+            results.append(r)
+            continue
+
+    local_branch, is_tag, remote_branch = classify_ref(repo)
+    if not (local_branch or is_tag or remote_branch):
+        r['action'] = 'ref MISSING'
+        r['status'] = 'err'
+        r['branch'] = r['remote'] = r['submod'] = '—'
+        results.append(r)
+        continue
+
+    sm_before = submodule_sha_map(repo)
+    rc, cur_branch, _ = git(repo, 'rev-parse', '--abbrev-ref', 'HEAD')
+    cur_branch = cur_branch if rc == 0 else '?'
+
+    co_args = ['checkout']
+    if force:
+        co_args.append('-f')
+    co_args.append(ref)
+    cc, _, co_err = git(repo, *co_args)
+    if cc != 0:
+        msg = co_err.lower()
+        if 'would be overwritten' in msg or 'local changes' in msg or 'untracked working tree' in msg:
+            r['action'] = 'FAILED (dirty)'
+        else:
+            r['action'] = 'FAILED'
+        r['status'] = 'err'
+        r['branch'] = r['remote'] = r['submod'] = '—'
+        results.append(r)
+        continue
+
+    rc, new_branch, _ = git(repo, 'rev-parse', '--abbrev-ref', 'HEAD')
+    new_branch = new_branch if rc == 0 else '?'
+
+    if new_branch == 'HEAD' and is_tag:
+        r['action'] = 'on tag'
+        r['branch'] = f'({ref})'
+    elif new_branch == cur_branch:
+        r['action'] = 'no-change'
+        r['branch'] = new_branch
+    else:
+        r['action'] = 'switched'
+        r['branch'] = new_branch
+
+    if new_branch != 'HEAD':
+        rcu, _, _ = git(repo, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', 'HEAD@{u}')
+        if rcu == 0:
+            rcab, ab, _ = git(repo, 'rev-list', '--left-right', '--count', 'HEAD...@{u}')
+            if rcab == 0 and ab:
+                try:
+                    ahead_n, behind_n = (int(x) for x in ab.split())
+                except ValueError:
+                    ahead_n = behind_n = 0
+                if ahead_n == 0 and behind_n == 0:
+                    r['remote'] = '='
+                else:
+                    parts = []
+                    if ahead_n:  parts.append(f'+{ahead_n}')
+                    if behind_n: parts.append(f'-{behind_n}')
+                    r['remote'] = ' '.join(parts)
+                    if r['status'] == 'ok':
+                        r['status'] = 'warn'
+            else:
+                r['remote'] = '?'
+        else:
+            r['remote'] = 'no-upstream'
+    else:
+        r['remote'] = '—'
+
+    sm_after = submodule_sha_map(repo)
+    all_keys = set(sm_before) | set(sm_after)
+    changed = sum(1 for k in all_keys if sm_before.get(k) != sm_after.get(k))
+    if changed:
+        r['submod'] = f'changed {changed}'
+        if r['status'] == 'ok':
+            r['status'] = 'warn'
+    elif sm_after:
+        r['submod'] = f'ok ({len(sm_after)})'
+    else:
+        r['submod'] = '—'
+
+    results.append(r)
+
+progress_clear()
+
+# --- Render the table ------------------------------------------------------
+col_repo   = max(len('Repository'), max((len(r['rel'])    for r in results), default=10))
+col_action = max(len('Action'),     max((len(r['action']) for r in results), default=6))
+col_branch = max(len('Branch'),     max((len(r['branch']) for r in results), default=6))
+col_remote = max(len('Remote'),     max((len(r['remote']) for r in results), default=6))
+col_submod = max(len('Submodules'), max((len(r['submod']) for r in results), default=10))
+
+hdr = (
+    f"{'Repository':<{col_repo}}  "
+    f"{'Action':<{col_action}}  "
+    f"{'Branch':<{col_branch}}  "
+    f"{'Remote':<{col_remote}}  "
+    f"{'Submodules':<{col_submod}}"
+)
+print(hdr)
+print('-' * len(hdr))
+
+color_of = {'ok': GREEN, 'warn': YELLOW, 'err': RED}
+status_order = {'err': 0, 'warn': 1, 'ok': 2}
+
+for r in sorted(results, key=lambda x: (status_order[x['status']], x['rel'])):
+    line = (
+        f"{r['rel']:<{col_repo}}  "
+        f"{r['action']:<{col_action}}  "
+        f"{r['branch']:<{col_branch}}  "
+        f"{r['remote']:<{col_remote}}  "
+        f"{r['submod']:<{col_submod}}"
+    )
+    print(f"{color_of[r['status']]}{line}{NC}")
+
+# --- Summary line ----------------------------------------------------------
+ok_n   = sum(1 for r in results if r['status'] == 'ok')
+warn_n = sum(1 for r in results if r['status'] == 'warn')
+err_n  = sum(1 for r in results if r['status'] == 'err')
+print()
+print(
+    f"Summary: {GREEN}{ok_n} ok{NC}, "
+    f"{YELLOW}{warn_n} warn{NC}, "
+    f"{RED}{err_n} err{NC}"
+)
+
+if err_n or warn_n:
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+main() {
+    check_dependencies
+
+    local ref=""
+    local fetch="1"
+    local force="0"
+    local progress="on"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --no-fetch)
+                fetch="0"
+                ;;
+            --force|-f)
+                force="1"
+                ;;
+            --no-progress)
+                progress="off"
+                ;;
+            --help)
+                show_usage
+                exit 0
+                ;;
+            --*)
+                log_error "Invalid option: $1"
+                show_usage
+                exit 1
+                ;;
+            *)
+                if [[ -z "$ref" ]]; then
+                    ref="$1"
+                else
+                    log_error "Unexpected argument: $1"
+                    show_usage
+                    exit 1
+                fi
+                ;;
+        esac
+        shift
+    done
+
+    if [[ -z "$ref" ]]; then
+        log_error "Missing required argument: <ref>"
+        show_usage
+        exit 1
+    fi
+
+    do_checkout "$PWD" "$ref" "$fetch" "$force" "$progress"
+}
+
+main "$@"

--- a/usr/local/bin/cmds/version-control/push
+++ b/usr/local/bin/cmds/version-control/push
@@ -19,26 +19,244 @@ show_usage() {
     cat << EOF
 Usage: airlab vcs push [OPTIONS]
 
-Push changes from repositories specified in repos.yaml file. The yaml file lives in $AIRLAB_PATH/version-control
+Push changes from repositories.
+
+Default mode (no flag):
+    Run 'vcs push' (vcstool) in the current directory. Pushes whatever
+    vcstool discovers below PWD, branch refs only.
+
+Tag mode:
+    --tags=<name>       Push the named tag (instead of branch refs) once
+                        per unique remote URL. Walks PWD recursively, finds
+                        git repositories (skipping submodules), groups them
+                        by remote URL, and pushes from one clone per URL.
+                        Refuses if shared clones have the tag pointing at
+                        different commits, unless --force is also set.
+    --force             With --tags=, overwrite the remote tag and skip
+                        the drift gate.
+    --dry-run           With --tags=, show what would be pushed without
+                        actually pushing.
 
 Options:
-  --help              Display this help message and exit
+    --help              Display this help message and exit
 
 Examples:
-  airlab vcs push
+    airlab vcs push
+    airlab vcs push --tags=v1.0.0
+    airlab vcs push --tags=v1.0.0 --dry-run
+    airlab vcs push --tags=v1.0.0 --force
 
 Note: This script uses the 'vcs' command to interact with the repository.
 EOF
 }
 
-main() {
+check_dependencies() {
+    local deps=("git")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+}
 
-    REPO_NAME=repos.yaml
-    REBASE=true
+# Push a named tag, deduplicated by remote URL, with a drift gate.
+push_tag() {
+    local base_dir=$1
+    local tag_name=$2
+    local force=$3
+    local dry_run=$4
+
+    python3 - "$base_dir" "$tag_name" "$force" "$dry_run" <<'PYEOF'
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+GREEN  = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+NC     = "\033[0m"
+
+base_dir = os.path.abspath(sys.argv[1])
+tag_name = sys.argv[2]
+force    = sys.argv[3] == '1'
+dry_run  = sys.argv[4] == '1'
+
+def git(repo, *args, timeout=60):
+    r = subprocess.run(
+        ["git", "-C", repo] + list(args),
+        capture_output=True, text=True, timeout=timeout
+    )
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+def normalize_url(url):
+    if not url:
+        return None
+    url = url.strip()
+    if url.endswith('.git'):
+        url = url[:-4]
+    m = re.match(r'^(?:git@|ssh://(?:git@)?|https?://)([^/:]+)(?::\d+)?[:/](.+)$', url)
+    if m:
+        host, path = m.groups()
+        return f"{host.lower()}/{path}"
+    return url
+
+# --- Walk: same logic as vcs check / vcs tag ---
+repos = []
+def walk(path):
+    git_path = os.path.join(path, '.git')
+    if os.path.isdir(git_path):
+        rc, out, _ = git(path, 'rev-parse', '--show-superproject-working-tree')
+        if rc == 0 and out:
+            return  # submodule
+        repos.append(path)
+    elif os.path.isfile(git_path):
+        return
+    try:
+        entries = sorted(os.listdir(path))
+    except (PermissionError, OSError):
+        return
+    for entry in entries:
+        if entry == '.git' or entry.startswith('.'):
+            continue
+        full = os.path.join(path, entry)
+        if os.path.isdir(full) and not os.path.islink(full):
+            walk(full)
+
+walk(base_dir)
+
+if not repos:
+    print(f"{YELLOW}[INFO]{NC} No git repositories found under {base_dir}")
+    sys.exit(0)
+
+# --- Find repos that have the named tag locally; resolve to commit SHA ---
+infos = []
+for repo in repos:
+    rel = os.path.relpath(repo, base_dir)
+    rc1, url, _ = git(repo, 'config', '--get', 'remote.origin.url')
+    # Resolve tag to a commit (works for both annotated and lightweight).
+    rc2, tag_sha, _ = git(repo, 'rev-parse', '--verify', '--quiet', f'refs/tags/{tag_name}^{{commit}}')
+    has_tag = (rc2 == 0 and tag_sha)
+    if not has_tag:
+        continue
+    infos.append({
+        'path': repo,
+        'rel':  rel,
+        'url':  url if rc1 == 0 and url else None,
+        'norm': normalize_url(url) if rc1 == 0 else None,
+        'sha':  tag_sha,
+    })
+
+if not infos:
+    print(f"{RED}[ERROR]{NC} Tag '{tag_name}' not found in any repository under {base_dir}")
+    sys.exit(1)
+
+print(f"Found tag '{tag_name}' in {len(infos)} repositor{'y' if len(infos) == 1 else 'ies'}.")
+
+# --- Group by normalized URL ---
+groups = defaultdict(list)
+no_origin = []
+for info in infos:
+    if info['norm']:
+        groups[info['norm']].append(info)
+    else:
+        no_origin.append(info)
+
+# --- Drift gate: same tag pointing at different commits across clones ---
+drift_groups = []
+for url, group in groups.items():
+    shas = {g['sha'] for g in group if g['sha']}
+    if len(shas) > 1:
+        drift_groups.append((url, group, shas))
+
+if drift_groups and not force:
+    print()
+    print(f"{RED}[DRIFT]{NC} Cannot push: {len(drift_groups)} URL(s) have '{tag_name}' pointing at different commits across clones:")
+    for url, group, _ in sorted(drift_groups):
+        print(f"  {RED}✗{NC} {url}")
+        for g in sorted(group, key=lambda x: x['rel']):
+            short = (g['sha'] or '?')[:8]
+            print(f"      {short}  {g['rel']}")
+    print()
+    print(f"{RED}Aborting push.{NC} Resolve the drift, or re-run with --force to override.")
+    sys.exit(1)
+
+if drift_groups and force:
+    print(f"{YELLOW}[WARN]{NC} {len(drift_groups)} URL(s) have '{tag_name}' on different commits. --force was given; pushing whichever clone is chosen first.")
+
+print()
+verb = "Would push" if dry_run else "Pushing"
+print(f"{verb} tag '{tag_name}' to origin (deduplicated by remote URL)...")
+print()
+
+# --- One push per unique URL ---
+push_results = []
+skipped = 0
+for url in sorted(groups):
+    group = groups[url]
+    chosen = sorted(group, key=lambda g: g['rel'])[0]
+    skipped += len(group) - 1
+
+    push_args = ['push', 'origin']
+    if force:
+        push_args.append(f"+refs/tags/{tag_name}")
+    else:
+        push_args.append(f"refs/tags/{tag_name}")
+
+    if dry_run:
+        rendered = "git " + " ".join(push_args)
+        extra = f" (skipping {len(group) - 1} duplicate clone(s))" if len(group) > 1 else ""
+        print(f"  {YELLOW}[DRY]{NC} {url} ← from {chosen['rel']}: {rendered}{extra}")
+        push_results.append((url, True))
+        continue
+
+    rc, out, err = git(chosen['path'], *push_args, timeout=120)
+    if rc == 0:
+        extra = f" (skipped {len(group) - 1} duplicate clone(s))" if len(group) > 1 else ""
+        print(f"  {GREEN}✓{NC} {url} ← from {chosen['rel']}{extra}")
+        push_results.append((url, True))
+    else:
+        msg = (err or out).strip().splitlines()[0] if (err or out).strip() else f"exit {rc}"
+        print(f"  {RED}✗{NC} {url} ← from {chosen['rel']}: {msg}")
+        push_results.append((url, False))
+
+if no_origin:
+    print(f"  {YELLOW}![{NC} {len(no_origin)} repositor{'y has' if len(no_origin) == 1 else 'ies have'} the tag but no origin remote (skipped):")
+    for info in sorted(no_origin, key=lambda x: x['rel']):
+        print(f"      {info['rel']}")
+
+push_ok     = [p for p in push_results if p[1]]
+push_failed = sum(1 for p in push_results if not p[1])
+print()
+print(f"Push summary: {GREEN}{len(push_ok)} unique remote(s) pushed{NC}, "
+      f"{RED}{push_failed} failed{NC}, "
+      f"{skipped} duplicate clone(s) skipped.")
+
+sys.exit(1 if push_failed else 0)
+PYEOF
+}
+
+main() {
+    local TAGS=""
+    local FORCE=0
+    local DRY_RUN=0
+    local TAGS_SET=0
 
     # Parse command line arguments
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --tags=*)
+                TAGS="${1#--tags=}"
+                TAGS_SET=1
+                ;;
+            --force)
+                FORCE=1
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                ;;
             --help)
                 show_usage
                 exit 0
@@ -52,7 +270,19 @@ main() {
         shift
     done
 
-    vcs push
+    if [[ "$TAGS_SET" -eq 1 ]]; then
+        if [[ -z "$TAGS" ]]; then
+            log_error "--tags= requires a tag name"
+            exit 1
+        fi
+        check_dependencies
+        push_tag "$PWD" "$TAGS" "$FORCE" "$DRY_RUN"
+    else
+        if [[ "$FORCE" -eq 1 || "$DRY_RUN" -eq 1 ]]; then
+            log_warn "--force and --dry-run only apply to --tags=<name>; ignoring."
+        fi
+        vcs push
+    fi
 }
 
 # Run main function

--- a/usr/local/bin/cmds/version-control/tag
+++ b/usr/local/bin/cmds/version-control/tag
@@ -1,0 +1,468 @@
+#!/bin/bash
+
+# Exit on error, undefined variables, and pipe failures
+set -uo pipefail
+
+# Color codes for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly NC='\033[0m' # No Color
+
+# Logging functions
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+show_usage() {
+    cat << EOF
+Usage: airlab vcs tag <tag_name> [OPTIONS]
+
+Recursively create a git tag at HEAD of every repository under the current
+directory, skipping submodules.
+
+Arguments:
+  <tag_name>             Name of the tag to create (e.g. v1.0.0).
+
+Options:
+  -m, --message=<msg>    Tag message. Implies an annotated tag.
+                         Default: "airlab vcs tag <name> on <ISO date>".
+  --lightweight          Create a lightweight tag (no message). Mutually
+                         exclusive with -m / --message.
+  --force                Overwrite an existing local tag. With --push, also
+                         overwrites the remote tag and skips the drift gate.
+  --push                 After tagging, push the tag to origin once per
+                         unique remote URL (deduplicated). Refuses to push
+                         if shared clones are not on the same commit, unless
+                         --force is also set.
+  --dry-run              Print what would be done without making any changes.
+  --no-progress          Disable the progress bar shown during the initial
+                         scan and inspection phases (also auto-disabled
+                         when stderr is not a terminal).
+  --help                 Show this help message and exit.
+
+Workflow:
+  1. Run \`airlab vcs check\` to confirm all shared repos are on the same
+     commit.
+  2. Run \`airlab vcs tag <name> --push\` to tag every repo and publish.
+
+Notes:
+  - Tags are created at HEAD of each repository.
+  - A dirty working tree triggers a warning but does not block tagging.
+  - Submodules and linked worktrees (.git as a file, or a non-empty
+    superproject) are skipped.
+  - With --push, repositories sharing the same remote URL are pushed only
+    once. The repo with the lexicographically smallest path is chosen.
+
+Exit codes:
+  0  All operations succeeded.
+  1  At least one tag or push operation failed, or the drift gate refused.
+
+Examples:
+  airlab vcs tag v1.0.0
+  airlab vcs tag v1.0.0 --message="release 1.0"
+  airlab vcs tag v1.0.0 --push
+  airlab vcs tag v1.0.0 --push --force
+  airlab vcs tag v1.0.0 --dry-run
+EOF
+}
+
+check_dependencies() {
+    local deps=("git")
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            log_error "Required dependency '$dep' is not installed."
+            exit 1
+        fi
+    done
+}
+
+# Run the walk + tag (+ optional push) in a single Python heredoc so the
+# in-memory list of repos is reused across phases. Arguments are passed
+# positionally via sys.argv.
+do_tag() {
+    local base_dir=$1
+    local tag_name=$2
+    local message=$3
+    local lightweight=$4
+    local force=$5
+    local push=$6
+    local dry_run=$7
+    local progress=$8
+
+    python3 - "$base_dir" "$tag_name" "$message" "$lightweight" "$force" "$push" "$dry_run" "$progress" <<'PYEOF'
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+GREEN  = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED    = "\033[0;31m"
+NC     = "\033[0m"
+
+base_dir       = os.path.abspath(sys.argv[1])
+tag_name       = sys.argv[2]
+message        = sys.argv[3]
+lightweight    = sys.argv[4] == '1'
+force          = sys.argv[5] == '1'
+push           = sys.argv[6] == '1'
+dry_run        = sys.argv[7] == '1'
+progress_flag  = sys.argv[8]   # "off" if user passed --no-progress
+show_progress  = (progress_flag != "off") and sys.stderr.isatty()
+
+# --- Progress bar plumbing -------------------------------------------------
+# Renders to stderr only on a TTY. Throttled to ~25 fps. Used during the
+# walk and per-repo inspection phases (the silent ones); the tag and push
+# loops below already emit per-item status lines on stdout, so a competing
+# stderr bar would be redundant there.
+_last_render = [0.0]
+
+def _term_width():
+    try:
+        return shutil.get_terminal_size((80, 20)).columns
+    except Exception:
+        return 80
+
+def progress_line(label, i, total, item, force_render=False):
+    if not show_progress:
+        return
+    now = time.monotonic()
+    if not force_render and (now - _last_render[0]) < 0.04:
+        return
+    _last_render[0] = now
+    width = _term_width()
+    bar_w = 20
+    pct   = (i / total) if total else 1.0
+    fill  = int(bar_w * pct)
+    bar   = "█" * fill + "░" * (bar_w - fill)
+    head  = f"[{bar}] {i}/{total}  {label}: "
+    space = max(0, width - len(head) - 1)
+    if len(item) > space:
+        item = "…" + item[-(space - 1):] if space > 1 else ""
+    line = head + item
+    pad = max(0, width - len(line) - 1)
+    sys.stderr.write("\r" + line + (" " * pad))
+    sys.stderr.flush()
+
+def progress_clear():
+    if not show_progress:
+        return
+    width = _term_width()
+    sys.stderr.write("\r" + (" " * (width - 1)) + "\r")
+    sys.stderr.flush()
+
+def git(repo, *args, timeout=30):
+    r = subprocess.run(
+        ["git", "-C", repo] + list(args),
+        capture_output=True, text=True, timeout=timeout
+    )
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+def normalize_url(url):
+    if not url:
+        return None
+    url = url.strip()
+    if url.endswith('.git'):
+        url = url[:-4]
+    m = re.match(r'^(?:git@|ssh://(?:git@)?|https?://)([^/:]+)(?::\d+)?[:/](.+)$', url)
+    if m:
+        host, path = m.groups()
+        return f"{host.lower()}/{path}"
+    return url
+
+# --- Walk: find repos, descend through them, skip submodules ---
+repos = []
+def walk(path):
+    git_path = os.path.join(path, '.git')
+    if os.path.isdir(git_path):
+        rc, out, _ = git(path, 'rev-parse', '--show-superproject-working-tree')
+        if rc == 0 and out:
+            return  # submodule, skip
+        repos.append(path)
+        progress_line("scanning", len(repos), max(len(repos), 1),
+                      os.path.relpath(path, base_dir))
+    elif os.path.isfile(git_path):
+        return  # submodule or linked worktree, skip
+    try:
+        entries = sorted(os.listdir(path))
+    except (PermissionError, OSError):
+        return
+    for entry in entries:
+        if entry == '.git' or entry.startswith('.'):
+            continue
+        full = os.path.join(path, entry)
+        if os.path.isdir(full) and not os.path.islink(full):
+            walk(full)
+
+walk(base_dir)
+progress_clear()
+
+if not repos:
+    print(f"{YELLOW}[INFO]{NC} No git repositories found under {base_dir}")
+    sys.exit(0)
+
+# --- Collect per-repo state ---
+infos = []
+total = len(repos)
+for idx, repo in enumerate(repos, start=1):
+    rel = os.path.relpath(repo, base_dir)
+    progress_line("inspecting", idx, total, rel)
+    rc1, url, _ = git(repo, 'config', '--get', 'remote.origin.url')
+    rc2, sha, _ = git(repo, 'rev-parse', 'HEAD')
+    rc3, st, _  = git(repo, 'status', '--porcelain')
+    infos.append({
+        'path':  repo,
+        'rel':   rel,
+        'url':   url if rc1 == 0 and url else None,
+        'norm':  normalize_url(url) if rc1 == 0 else None,
+        'sha':   sha if rc2 == 0 and sha else None,
+        'dirty': bool(st),
+    })
+
+progress_clear()
+
+# Warn (don't block) on dirty repos.
+dirty = [i for i in infos if i['dirty']]
+if dirty:
+    print(f"{YELLOW}[WARN]{NC} {len(dirty)} repositor{'y has' if len(dirty) == 1 else 'ies have'} a dirty working tree (tagging proceeds against HEAD):")
+    for info in sorted(dirty, key=lambda x: x['rel']):
+        print(f"      {info['rel']}")
+    print()
+
+# --- Step 1: create the tag locally in every repo ---
+verb = "Would tag" if dry_run else "Tagging"
+print(f"{verb} {len(infos)} repositor{'y' if len(infos) == 1 else 'ies'} with '{tag_name}'...")
+print()
+
+tag_results = []  # list of (info, ok, err_summary)
+for info in sorted(infos, key=lambda x: x['rel']):
+    args = ['tag']
+    if force:
+        args.append('-f')
+    if not lightweight:
+        args += ['-a', '-m', message]
+    args.append(tag_name)
+
+    if dry_run:
+        rendered = "git " + " ".join(["'" + a + "'" if ' ' in a else a for a in args])
+        print(f"  {YELLOW}[DRY]{NC} {info['rel']}: {rendered}")
+        tag_results.append((info, True, 'dry-run'))
+        continue
+
+    rc, out, err = git(info['path'], *args)
+    if rc == 0:
+        short = (info['sha'] or '?')[:8]
+        print(f"  {GREEN}✓{NC} {info['rel']}  ({short})")
+        tag_results.append((info, True, ''))
+    else:
+        msg = (err or out).strip().splitlines()[0] if (err or out).strip() else f"exit {rc}"
+        print(f"  {RED}✗{NC} {info['rel']}: {msg}")
+        tag_results.append((info, False, msg))
+
+ok_tags     = [t for t in tag_results if t[1]]
+failed_tags = [t for t in tag_results if not t[1]]
+print()
+print(f"Tag summary: {GREEN}{len(ok_tags)} succeeded{NC}, {RED}{len(failed_tags)} failed{NC}")
+
+# --- Step 2: optional dedup-push ---
+push_failed = 0
+if push and not ok_tags:
+    print()
+    print(f"{YELLOW}[INFO]{NC} Skipping push: no tags were successfully created.")
+elif push:
+    print()
+    verb = "Would push" if dry_run else "Pushing"
+    print(f"{verb} tag '{tag_name}' to origin (deduplicated by remote URL)...")
+    print()
+
+    # Group successfully-tagged repos by normalized URL.
+    groups = defaultdict(list)
+    no_origin = []
+    for info, ok, _ in tag_results:
+        if not ok:
+            continue
+        if info['norm']:
+            groups[info['norm']].append(info)
+        else:
+            no_origin.append(info)
+
+    # Drift gate: refuse to push if any group's clones have different SHAs,
+    # unless --force was given.
+    drift_groups = []
+    for url, group in groups.items():
+        shas = {g['sha'] for g in group if g['sha']}
+        if len(shas) > 1:
+            drift_groups.append((url, group, shas))
+
+    if drift_groups and not force:
+        print(f"{RED}[DRIFT]{NC} Cannot push: {len(drift_groups)} shared repositor{'y is' if len(drift_groups) == 1 else 'ies are'} on different commits:")
+        for url, group, _ in sorted(drift_groups):
+            print(f"  {RED}✗{NC} {url}")
+            for g in sorted(group, key=lambda x: x['rel']):
+                short = (g['sha'] or '?')[:8]
+                print(f"      {short}  {g['rel']}")
+        print()
+        print(f"{RED}Aborting push.{NC} Run 'airlab vcs check' to see drift, or re-run with --force to override.")
+        sys.exit(1)
+
+    if drift_groups and force:
+        print(f"{YELLOW}[WARN]{NC} {len(drift_groups)} URL(s) have clones on different commits. --force was given; pushing whichever clone is chosen first.")
+        print()
+
+    # One push per unique URL: lexicographically first repo path.
+    push_results = []
+    skipped = 0
+    for url in sorted(groups):
+        group = groups[url]
+        chosen = sorted(group, key=lambda g: g['rel'])[0]
+        skipped += len(group) - 1
+
+        push_args = ['push', 'origin']
+        if force:
+            push_args.append(f"+refs/tags/{tag_name}")
+        else:
+            push_args.append(f"refs/tags/{tag_name}")
+
+        if dry_run:
+            rendered = "git " + " ".join(push_args)
+            extra = f" (skipping {len(group) - 1} duplicate clone(s))" if len(group) > 1 else ""
+            print(f"  {YELLOW}[DRY]{NC} {url} ← from {chosen['rel']}: {rendered}{extra}")
+            push_results.append((url, True))
+            continue
+
+        rc, out, err = git(chosen['path'], *push_args, timeout=120)
+        if rc == 0:
+            extra = f" (skipped {len(group) - 1} duplicate clone(s))" if len(group) > 1 else ""
+            print(f"  {GREEN}✓{NC} {url} ← from {chosen['rel']}{extra}")
+            push_results.append((url, True))
+        else:
+            msg = (err or out).strip().splitlines()[0] if (err or out).strip() else f"exit {rc}"
+            print(f"  {RED}✗{NC} {url} ← from {chosen['rel']}: {msg}")
+            push_results.append((url, False))
+
+    if no_origin:
+        print(f"  {YELLOW}![{NC} {len(no_origin)} tagged repositor{'y has' if len(no_origin) == 1 else 'ies have'} no origin remote and were not pushed:")
+        for info in sorted(no_origin, key=lambda x: x['rel']):
+            print(f"      {info['rel']}")
+
+    push_ok     = [p for p in push_results if p[1]]
+    push_failed = sum(1 for p in push_results if not p[1])
+    print()
+    print(f"Push summary: {GREEN}{len(push_ok)} unique remote(s) pushed{NC}, "
+          f"{RED}{push_failed} failed{NC}, "
+          f"{skipped} duplicate clone(s) skipped.")
+
+if failed_tags or push_failed:
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+main() {
+    check_dependencies
+
+    if [[ $# -eq 0 ]]; then
+        log_error "Tag name is required."
+        show_usage
+        exit 1
+    fi
+
+    # First positional argument that doesn't start with '-' is the tag name.
+    local TAG_NAME=""
+    local MESSAGE=""
+    local LIGHTWEIGHT=0
+    local FORCE=0
+    local PUSH=0
+    local DRY_RUN=0
+    local MESSAGE_SET=0
+    local PROGRESS="on"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --help)
+                show_usage
+                exit 0
+                ;;
+            --lightweight)
+                LIGHTWEIGHT=1
+                ;;
+            --force)
+                FORCE=1
+                ;;
+            --push)
+                PUSH=1
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                ;;
+            --no-progress)
+                PROGRESS="off"
+                ;;
+            --message=*)
+                MESSAGE="${1#--message=}"
+                MESSAGE_SET=1
+                ;;
+            -m=*)
+                MESSAGE="${1#-m=}"
+                MESSAGE_SET=1
+                ;;
+            -m|--message)
+                shift
+                if [[ $# -eq 0 ]]; then
+                    log_error "Option requires an argument: --message"
+                    exit 1
+                fi
+                MESSAGE="$1"
+                MESSAGE_SET=1
+                ;;
+            --)
+                shift
+                if [[ -z "$TAG_NAME" && $# -gt 0 ]]; then
+                    TAG_NAME="$1"
+                    shift
+                fi
+                break
+                ;;
+            -*)
+                log_error "Invalid option: $1"
+                show_usage
+                exit 1
+                ;;
+            *)
+                if [[ -z "$TAG_NAME" ]]; then
+                    TAG_NAME="$1"
+                else
+                    log_error "Unexpected positional argument: $1"
+                    show_usage
+                    exit 1
+                fi
+                ;;
+        esac
+        shift
+    done
+
+    if [[ -z "$TAG_NAME" ]]; then
+        log_error "Tag name is required."
+        show_usage
+        exit 1
+    fi
+
+    if [[ "$LIGHTWEIGHT" -eq 1 && "$MESSAGE_SET" -eq 1 ]]; then
+        log_error "--lightweight is mutually exclusive with -m / --message"
+        exit 1
+    fi
+
+    # Default message for annotated tags.
+    if [[ "$LIGHTWEIGHT" -eq 0 && "$MESSAGE_SET" -eq 0 ]]; then
+        MESSAGE="airlab vcs tag $TAG_NAME on $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    fi
+
+    do_tag "$PWD" "$TAG_NAME" "$MESSAGE" "$LIGHTWEIGHT" "$FORCE" "$PUSH" "$DRY_RUN" "$PROGRESS"
+}
+
+# Run main function
+main "$@"

--- a/usr/local/bin/cmds/version-control/vcs
+++ b/usr/local/bin/cmds/version-control/vcs
@@ -11,9 +11,12 @@ function show_usage() {
     echo "Available commands:"
     echo "  init    Initialize a new AirLab project"
     echo "  pull    Pull changes from the remote repository"
-    echo "  push    Push local changes to the remote repository"
+    echo "  push    Push local changes to the remote repository (or a tag with --tags=)"
     echo "  status  Show the current status of the AirLab project"
     echo "  update  Pull, init missing repos, and pull again with summary"
+    echo "  check   Find drift across cloned repos or across version_control YAMLs"
+    echo "  tag     Recursively tag all git repos under the current directory"
+    echo "  checkout  Recursively git checkout <ref> in every repo under PWD"
     echo
     echo "Options:"
     echo "  --help  Show this help message"
@@ -55,6 +58,18 @@ case "$COMMAND" in
     update)
         # Pull, init missing repos, pull again
         /usr/local/bin/cmds/version-control/update "$@"
+        ;;
+    check)
+        # Drift check (filesystem walk or version_control YAMLs)
+        /usr/local/bin/cmds/version-control/check "$@"
+        ;;
+    tag)
+        # Recursively tag all repos under PWD
+        /usr/local/bin/cmds/version-control/tag "$@"
+        ;;
+    checkout)
+        # Recursively checkout a ref in every repo under PWD
+        /usr/local/bin/cmds/version-control/checkout "$@"
         ;;
     --help)
         show_usage

--- a/usr/local/bin/docs/set_hosts.md
+++ b/usr/local/bin/docs/set_hosts.md
@@ -1,0 +1,97 @@
+# set_hosts
+
+## Overview
+The `airlab set_hosts` command updates `/etc/hosts` on a local or remote machine with hostname-to-IP mappings derived from `robot.conf`. This allows robot names to be used directly in commands like `ping mt001` or `ssh mt001` without needing to remember IP addresses.
+
+## Syntax
+```bash
+airlab set_hosts <target> [options]
+```
+
+## Arguments
+- `<target>`: Either `local` (update the local machine) or a robot name from `robot.conf` (update the remote robot via SSH).
+
+## Options
+- `--password`: Skip key-based SSH authentication and prompt for a password directly (remote targets only).
+- `--help`: Display usage information.
+
+## How It Works
+
+### Entry Generation
+The command reads all entries from `$AIRLAB_PATH/robot/robot.conf` (format: `name=user@ip`) and generates `/etc/hosts` lines:
+```
+10.223.1.99     mt001
+10.3.1.102      mt002
+```
+
+Entries using `ssh://` URIs (e.g., `ssh://user@host:port` for port-forwarded connections) are automatically skipped, since they share a single hostname with different ports and don't map to unique IPs. Skipped entries are logged for visibility.
+
+### Markers
+Entries are placed between fenced markers in `/etc/hosts`:
+```
+# Airlab Hosts Start
+10.223.1.99     mt001
+10.3.1.102      mt002
+# Airlab Hosts End
+```
+
+- If the markers already exist, only the content between them is replaced (everything between the markers is removed and new entries are inserted).
+- If the markers don't exist, a new section is appended to the end of the file.
+
+### Backup
+Before any modification, a timestamped backup of `/etc/hosts` is created:
+```
+/etc/hosts_20260429_160345
+```
+
+### Conflict Detection
+Before writing, the command checks for conflicts between the new entries and existing `/etc/hosts` entries **outside** the airlab markers:
+- **Hostname conflict**: A robot name already appears in `/etc/hosts` mapped to a different IP.
+- **IP overlap**: An IP from `robot.conf` already appears in `/etc/hosts` mapped to a different hostname.
+
+If any conflicts are detected, the command warns and aborts without modifying the file.
+
+### Remote Operation
+When targeting a remote robot, the command:
+1. Looks up the robot's SSH address from `robot.conf`.
+2. Authenticates via SSH (key-based first, falls back to password, or uses `--password` to skip key-based).
+3. Reads the remote `/etc/hosts`, performs conflict checks, creates a remote backup, and writes the updated file.
+
+## Examples
+
+### Local
+```bash
+# Update local /etc/hosts with all robots from robot.conf
+airlab set_hosts local
+```
+
+### Remote
+```bash
+# Update /etc/hosts on mt001
+airlab set_hosts mt001
+
+# Use password authentication
+airlab set_hosts mt001 --password
+```
+
+## Configuration Files
+- **Robot config**: `$AIRLAB_PATH/robot/robot.conf` — source of hostname-to-IP mappings.
+
+## Dependencies
+- `ssh`, `sshpass` — for remote operations
+- `sudo` — required to modify `/etc/hosts`
+
+## Error Handling
+- Validates that `robot.conf` exists and contains entries.
+- Validates that the target robot exists in `robot.conf` (for remote targets).
+- Checks for hostname/IP conflicts before writing.
+- Creates a backup before every modification.
+- Provides colored error/warning/info messages.
+
+## Troubleshooting
+
+### Common Issues
+1. "Permission denied": The command uses `sudo` to modify `/etc/hosts`. Ensure your user has `sudo` privileges.
+2. "Conflicts detected": Another entry in `/etc/hosts` (outside the airlab markers) uses the same hostname or IP. Resolve the conflict manually, then re-run.
+3. "Robot not found in robot.conf": Verify the robot name matches an entry in `$AIRLAB_PATH/robot/robot.conf`.
+4. "SSH connection failed": Check network connectivity and credentials, or use `--password`.

--- a/usr/local/bin/docs/setup.md
+++ b/usr/local/bin/docs/setup.md
@@ -65,8 +65,8 @@ When running airlab setup <system_name>, the command:
 - Installs or updates the Airlab package
 - Configures the remote environment(airlab.env file)
 - Updates the remote .bashrc file
-- Updates the /etc/hosts file on host system. It creates an alias so that you directly ssh using hostname like `ping robot1`
-- Syncs the /etc/hosts file to the remote system so that it remains consistent across systems. It does not change system generated information
+
+> **Note:** To update `/etc/hosts` with robot hostname mappings, use `airlab set_hosts local` (for the local machine) or `airlab set_hosts <robot_name>` (for a remote robot). See the [set_hosts documentation](/usr/local/bin/docs/set_hosts.md) for details.
 
 ## Error Handling
 

--- a/usr/local/bin/docs/version-control-commands.md
+++ b/usr/local/bin/docs/version-control-commands.md
@@ -5,9 +5,12 @@ A suite of local version control system (VCS) commands for managing multiple rep
 ## Commands Overview
 - [init](#init): Initialize local repositories from a YAML configuration
 - [pull](#pull): Pull changes from remote repositories to local workspace
-- [push](#push): Push local changes to remote repositories
+- [push](#push): Push local changes to remote repositories (or a tag with `--tags=`)
 - [status](#status): Check local repository status
 - [update](#update): Pull, init missing repos, and pull again with summary
+- [check](#check): Find drift across cloned repos or version_control YAMLs
+- [tag](#tag): Recursively tag git repositories under the current directory
+- [checkout](#checkout): Recursively `git checkout <ref>` (branch or tag) in every repo under PWD, with a colored post-state summary
 - [examples](#examples)
 
 ## init
@@ -62,7 +65,7 @@ airlab vcs pull [OPTIONS]
 ## push
 
 ### Description
-Pushes changes from your local workspace to remote repositories.
+Pushes changes from your local workspace to remote repositories. With `--tags=<name>`, pushes a single named tag, deduplicated by remote URL with the same drift gate as `tag --push`.
 
 ### Usage
 ```bash
@@ -70,10 +73,15 @@ airlab vcs push [OPTIONS]
 ```
 
 ### Options
+- `--tags=<name>`: Push the named tag instead of branch refs. Walks PWD recursively, finds git repositories (skipping submodules), groups them by remote URL, and pushes from one clone per URL. Refuses if shared clones have the tag pointing at different commits, unless `--force` is also given.
+- `--force`: With `--tags=`, overwrite the remote tag and skip the drift gate.
+- `--dry-run`: With `--tags=`, show what would be pushed without actually pushing.
 - `--help`: Display help message
 
 ### Features
-- Pushes local changes to remote repositories specified in YAML file
+- Default mode pushes local changes to remote repositories via `vcs push` (vcstool)
+- `--tags=<name>` mode pushes a tag once per unique remote URL (deduplicated)
+- Drift gate refuses to push if the same tag points at different commits across shared clones
 - Provides colored output for status updates
 
 ## status
@@ -117,6 +125,119 @@ airlab vcs update [OPTIONS]
 - Must be run from the directory containing `AIRLAB_REPO_FILE`
 - Provides a colored summary of succeeded and failed pulls
 - Automatically initializes any newly added repos from the YAML file
+
+## check
+
+### Description
+Find drift across repositories. Two complementary modes:
+
+- **Default (filesystem mode)**: Walks the current directory recursively, finds every git repository (skipping submodules), groups them by remote URL, and flags any group whose clones are not all on the same commit. Run this from `$AIRLAB_PATH` before `airlab vcs tag` to make sure shared clones agree.
+- **`--version-control` mode**: Reads every YAML file under `$AIRLAB_PATH/version_control/`. Flags any URL pinned to multiple `version:` values across YAMLs, and any duplicate URLs within a single YAML.
+
+### Usage
+```bash
+airlab vcs check [OPTIONS]
+```
+
+### Options
+- `--version-control`: Scan YAMLs in `$AIRLAB_PATH/version_control/` instead of walking PWD.
+- `--no-progress`: Disable the progress bar (also auto-disabled when stderr is not a terminal).
+- `--help`: Display help message.
+
+### Features
+- Skips submodules and linked worktrees automatically (`.git` as a file, or non-empty `git rev-parse --show-superproject-working-tree`).
+- Normalizes equivalent ssh and https URLs (so `git@github.com:org/repo` and `https://github.com/org/repo` group together).
+- Color-coded output: green when clean, yellow for branch-only skew or non-blocking notes, red for commit-level drift or duplicates.
+- Exits 0 when clean, 1 on drift / duplicates / parse errors — usable in scripts.
+
+### Output sections (filesystem mode)
+- `[DRIFT]` — shared URLs whose clones are at different commits (red)
+- `[BRANCH SKEW]` — same commit but different branches (yellow)
+- `[OK]` — shared URLs all in sync (green)
+- `[NO ORIGIN]` — repositories without an origin remote, excluded from grouping
+- `[DIRTY]` — repositories with uncommitted changes
+
+### Output sections (`--version-control` mode)
+- `[VERSION DRIFT]` — URLs pinned to multiple `version:` values across YAMLs
+- `[DUPLICATE URL]` — same URL listed under more than one repository name in a single YAML
+- `[PARSE ERROR]` — YAML files that failed to load
+
+## tag
+
+### Description
+Recursively create a git tag at HEAD of every repository under the current directory, skipping submodules. Optionally push the tag to origin once per unique remote URL (deduplicated, with a drift gate).
+
+### Usage
+```bash
+airlab vcs tag <tag_name> [OPTIONS]
+```
+
+### Arguments
+- `<tag_name>`: Name of the tag to create (e.g. `v1.0.0`).
+
+### Options
+- `-m, --message=<msg>`: Annotated tag message. Default: `airlab vcs tag <name> on <ISO date>`.
+- `--lightweight`: Create a lightweight tag (no message). Mutually exclusive with `-m` / `--message`.
+- `--force`: Overwrite an existing local tag. With `--push`, also overwrites the remote tag and skips the drift gate.
+- `--push`: After tagging, push the tag to origin once per unique remote URL. Refuses to push if shared clones are not on the same commit, unless `--force` is also set. The repo with the lexicographically smallest path is chosen as the source for each push.
+- `--dry-run`: Print what would be done without making any changes.
+- `--no-progress`: Disable the progress bar shown during the initial scan and inspection phases (also auto-disabled when stderr is not a terminal).
+- `--help`: Display help message.
+
+### Features
+- Annotated tags by default, with an auto-generated message.
+- Walks PWD with the same logic as `airlab vcs check` (skips submodules, descends through repos to find nested clones).
+- Warns on dirty working trees but does not refuse to tag.
+- With `--push`, deduplicates by URL — so a repo cloned in 19 workspaces is pushed once, not 19 times.
+- Drift gate prevents publishing a tag whose underlying commit differs across shared clones.
+
+### Recommended workflow
+1. `airlab vcs check` (fix any `[DRIFT]` cases first)
+2. `airlab vcs tag <name>` to validate locally
+3. `airlab vcs push --tags=<name>` (or re-run `airlab vcs tag <name> --push`) to publish
+
+## checkout
+
+### Description
+Recursively run `git checkout <ref>` in every repository under the current directory, skipping submodules. `<ref>` may be a branch or tag. After each checkout, the new state is summarized in a colored table.
+
+### Usage
+```bash
+airlab vcs checkout <ref> [OPTIONS]
+```
+
+### Arguments
+- `<ref>`: Branch or tag name to check out.
+
+### Options
+- `--no-fetch`: Skip `git fetch --tags origin` before checkout. Faster, but tag availability and ahead/behind counts may be stale.
+- `--force`, `-f`: Pass `-f` to `git checkout`, discarding local uncommitted changes. Use with care.
+- `--no-progress`: Disable the progress bar (also auto-disabled when stderr is not a terminal).
+- `--help`: Display help message.
+
+### Behavior
+1. Walks PWD with the same logic as `airlab vcs check` (skips submodules and linked worktrees).
+2. For each repo: `git fetch --quiet --tags origin` (unless `--no-fetch`). Fetch failure is reported per-repo and stops that repo's processing.
+3. For each repo: `git checkout <ref>` (or with `-f` when `--force`).
+   - If `<ref>` is a branch on `origin` but not yet local, git's DWIM creates a tracking branch automatically.
+   - If `<ref>` is a tag, the result is a detached HEAD (reported as `on tag`).
+   - If `<ref>` does not exist on the repo (not a local branch, not a tag, not `origin/<ref>`), the row reports `ref MISSING`.
+   - If the working tree is dirty and checkout would overwrite changes, the row reports `FAILED (dirty)` (use `--force` to override).
+4. After a successful checkout, the script reports:
+   - Ahead/behind upstream when on a branch with tracking (`+N`/`-N`).
+   - Submodule SHA changes (the recorded SHA of any submodule changing between pre- and post-checkout is counted).
+
+### Output sections
+- Per-repo row colored by status:
+  - **green** `ok` — checked out, on ref, up to date (or no remote to compare against).
+  - **yellow** `warn` — checked out but ahead/behind upstream, or submodule SHAs changed.
+  - **red** `err` — `ref MISSING`, `FAILED`, `FAILED (dirty)`, or `fetch FAILED`.
+- Rows are sorted err → warn → ok, then by path.
+- A trailing summary line counts repos in each status bucket.
+
+### Exit codes
+- `0` — all repos cleanly on the requested ref and up to date.
+- `1` — any repo has a `warn` or `err` status.
 
 ## Common Features
 
@@ -185,4 +306,37 @@ airlab vcs status --show-branch
 
 # pull, init missing repos, and pull again with summary
 airlab vcs update
+
+# check for commit drift among shared repositories under PWD
+airlab vcs check
+
+# check for version drift across version_control YAMLs (and intra-YAML duplicates)
+airlab vcs check --version-control
+
+# create an annotated tag in every repo under PWD (skipping submodules)
+airlab vcs tag v1.0.0
+
+# tag and push, deduplicated by remote URL, with drift gate
+airlab vcs tag v1.0.0 --push
+
+# overwrite an existing tag locally and on the remote
+airlab vcs tag v1.0.0 --push --force
+
+# preview a tag operation without making changes
+airlab vcs tag v1.0.0 --push --dry-run
+
+# push an existing tag (after the fact), deduplicated
+airlab vcs push --tags=v1.0.0
+
+# recursively check out 'main' in every repo under PWD (fetches first)
+airlab vcs checkout main
+
+# check out a tag in every repo; repos without that tag are reported
+airlab vcs checkout v1.0.0
+
+# faster checkout when you already fetched recently
+airlab vcs checkout main --no-fetch
+
+# discard local uncommitted changes during checkout
+airlab vcs checkout main --force
 ```

--- a/usr/share/airlab/install_source
+++ b/usr/share/airlab/install_source
@@ -1,0 +1,1 @@
+kabirkedia/airlab

--- a/usr/share/zsh/vendor-completions/_airlab
+++ b/usr/share/zsh/vendor-completions/_airlab
@@ -98,9 +98,12 @@ _airlab_vcs() {
     vcs_commands=(
         'init:Clone repos from YAML'
         'pull:Pull repos'
-        'push:Push repos'
+        'push:Push repos (or a tag with --tags=)'
         'status:Show repo status'
         'update:Pull + init missing + pull again'
+        'check:Find drift across cloned repos or version_control YAMLs'
+        'tag:Recursively tag git repos under PWD'
+        'checkout:Recursively git checkout a branch or tag in every repo under PWD'
     )
 
     local state line context
@@ -132,12 +135,44 @@ _airlab_vcs() {
                         '--no-rebase[do not rebase]' \
                         '--help[show help]'
                     ;;
-                push|update)
+                push)
+                    _arguments -s \
+                        '--tags=[push a named tag, deduplicated]:tag name:' \
+                        '--force[overwrite remote tag and skip drift gate]' \
+                        '--dry-run[show what would be pushed]' \
+                        '--help[show help]'
+                    ;;
+                update)
                     _arguments -s '--help[show help]'
                     ;;
                 status)
                     _arguments -s \
                         '--show-branch[show branch info]' \
+                        '--help[show help]'
+                    ;;
+                check)
+                    _arguments -s \
+                        '--version-control[scan version_control YAMLs instead of PWD]' \
+                        '--no-progress[disable the progress bar]' \
+                        '--help[show help]'
+                    ;;
+                tag)
+                    _arguments -s \
+                        '--message=[annotated tag message]:message:' \
+                        '-m[annotated tag message]:message:' \
+                        '--lightweight[create a lightweight tag]' \
+                        '--force[overwrite existing local tag (and remote with --push)]' \
+                        '--push[push tag to origin, deduped]' \
+                        '--dry-run[show what would be done]' \
+                        '--no-progress[disable the progress bar]' \
+                        '--help[show help]'
+                    ;;
+                checkout)
+                    _arguments -s \
+                        '--no-fetch[skip git fetch --tags before checkout]' \
+                        '--force[discard local uncommitted changes (-f to git checkout)]' \
+                        '-f[discard local uncommitted changes (-f to git checkout)]' \
+                        '--no-progress[disable the progress bar]' \
                         '--help[show help]'
                     ;;
             esac
@@ -161,6 +196,7 @@ _airlab() {
         'docker-up:Start Docker containers using docker-compose'
         'docker-join:Attach to a running Docker container'
         'docker-list:List active Docker containers'
+        'docker-clean:Stop and remove all Docker containers'
         'vcs:Manage multiple repositories with common git functions'
         'cd:Change directory relative to \$AIRLAB_PATH'
     )
@@ -184,11 +220,15 @@ _airlab() {
             local cmd="${line[1]}"
             case "$cmd" in
                 setup)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_targets
                         compadd -- --help
                         return
                     fi
+                    # For positions after the target, drop the subcommand
+                    # so _arguments parses flags from words[1] onwards.
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s \
                         '--path=[path]:path:_airlab_complete_airlab_path' \
                         '--force[force setup]' \
@@ -197,31 +237,37 @@ _airlab() {
                     ;;
 
                 ssh)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_robots
                         compadd -- --help
                         return
                     fi
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s \
                         '--password[use password auth]' \
                         '--help[show help]'
                     ;;
 
                 auth|ping)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_robots
                         compadd -- --help
                         return
                     fi
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s '--help[show help]'
                     ;;
 
                 sync)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_robots
                         compadd -- --help
                         return
                     fi
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s \
                         '--dry-run[dry run]' \
                         '--delete[delete extraneous files]' \
@@ -234,11 +280,13 @@ _airlab() {
                     ;;
 
                 launch)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_targets
                         compadd -- --help
                         return
                     fi
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s \
                         '--yaml_file=[YAML file]:yaml file:' \
                         '--stop[stop launch]' \
@@ -247,15 +295,30 @@ _airlab() {
                     ;;
 
                 set_env)
-                    if (( CURRENT == 1 )); then
+                    if (( CURRENT == 2 )); then
                         _airlab_complete_targets
                         compadd -- --help -h
                         return
                     fi
+                    shift words
+                    (( CURRENT-- ))
                     _arguments -s \
                         '--password[use password auth]' \
                         '--help[show help]' \
                         '-h[show help]'
+                    ;;
+
+                set_hosts)
+                    if (( CURRENT == 2 )); then
+                        _airlab_complete_targets
+                        compadd -- --help
+                        return
+                    fi
+                    shift words
+                    (( CURRENT-- ))
+                    _arguments -s \
+                        '--password[use password auth]' \
+                        '--help[show help]'
                     ;;
 
                 docker-build)
@@ -286,6 +349,15 @@ _airlab() {
                     _arguments -s \
                         '--system=[system name]:system:' \
                         '--images[list images]' \
+                        '--password[use password auth]' \
+                        '--help[show help]'
+                    ;;
+
+                docker-clean)
+                    _arguments -s \
+                        '--system=[system name]:system:' \
+                        '--yes[skip confirmation prompt]' \
+                        '-y[skip confirmation prompt]' \
                         '--password[use password auth]' \
                         '--help[show help]'
                     ;;


### PR DESCRIPTION
This PR brings `kabirkedia/airlab` in sync with the work done on the `strapsai/airlab` fork since the last upstream PR (#25). At the file level strapsai is a pure superset of upstream — every file present here is also present on strapsai, and no upstream-only changes need to be merged the other way.

Opened as a **draft** so it can be reviewed end-to-end before going live.

## What's in this PR

### New `vcs` subcommands

- **`vcs check`** — finds drift across cloned repos under PWD (groups by remote URL, flags clones at different commits) OR scans `$AIRLAB_PATH/version_control/*.yaml` for cross-YAML version drift and intra-YAML duplicate URLs (`--version-control`). TTY-aware stderr progress bar with `--no-progress` opt-out.
- **`vcs tag <name>`** — recursive tagging at HEAD across every repo under PWD. Annotated by default. Optional `--push` does dedup-by-URL with a drift gate that refuses to publish if shared clones diverged (`--force` overrides). Same progress bar.
- **`vcs push --tags=<name>`** — after-the-fact tag publishing via the same dedup + drift-gate path.
- **`vcs checkout <ref>`** — recursive `git checkout` (branch or tag). Default-on `git fetch --tags`, `--no-fetch` to skip. Skips dirty trees and reports `FAILED (dirty)` (`--force` overrides). Uses git's DWIM to auto-create tracking branches when `<ref>` exists on origin but not yet locally. Colored per-repo table sorted err → warn → ok: `ref MISSING`, ahead/behind upstream (`+N`/`-N`), submodule SHA changes.

### Other new commands

- **`docker-clean`** — stops and removes all containers + dangling images.
- **`set_hosts`** — restored. Rewrites `/etc/hosts` between marker comments from `robot.conf` with conflict detection and a backup. CLAUDE.md's "Known Issues" entry about set_hosts having no implementation is removed accordingly.

### `setup` improvements

- **`setup local`**: `GROUP_NAME` is now `$(id -gn $current_user)` (the actual group) rather than `$current_user`. Answering `N` to the overwrite prompt no longer clobbers user-edited `DOCKER_BUILD_PATH` / `DOCKER_UP_PATH` / `LAUNCH_FILE_PATH` in the env file.
- **`setup <robot>`**: allocates a pty (`ssh -tt`) on the install.sh invocation so sudo's tty-based timestamp cache survives from `sudo -S echo HERE` into install.sh's internal `sudo apt` / `sudo dpkg` calls. install.sh continues to run as the user (not root) so its `~/VENVs` and `~/.bashrc` edits use the correct `$HOME`. (Fixes a real bug we hit when `apt update` inside install.sh prompted for a password that never reached anywhere.)
- **`setup <robot>`**: replaces the rsync-the-working-tree payload with `git clone --depth 1 --branch main` of the local repo's origin, executed as `$SUDO_USER`. Prints a local-vs-main diff and prompts y/N if uncommitted or ahead; `--force` skips the prompt. Robots get the canonical reviewed state, not whatever happens to be in the host's working tree.

### `install_source` mechanism

A new file `usr/share/airlab/install_source` is shipped in the .deb and records which `<org>/<repo>` `airlab setup <robot>` should curl the source zip from (replacing the previously hardcoded URL in `cmds/robot-setup`). **For this PR the file is set to `kabirkedia/airlab`** — i.e. upstream's own value.

`install.sh` then auto-detects the build's origin via `git remote get-url origin` and overwrites the staged `usr/share/airlab/install_source` before `dpkg-deb --build`. So:

- Building from a `kabirkedia/airlab` checkout → .deb has `kabirkedia/airlab`. Matches static file.
- Building from any fork (e.g. `strapsai/airlab`) → .deb has that fork's `<org>/<repo>` regardless of what the in-repo file says.
- Building from an unzipped archive (no `.git`) → falls back to the static file value (here, `kabirkedia/airlab`).

URL parser handles SSH, HTTPS with/without `.git`, and `ssh://` with optional port. Non-GitHub or malformed remotes fall through and leave the static file in place.

Net effect: cross-fork merges of `install_source` are self-correcting on next local rebuild.

### `--skip-apt` flag

`install.sh` and `install_dependencies_ubuntu24.sh` both accept `--skip-apt` to skip the `sudo apt` calls — useful when apt deps are already installed or are managed externally (conda, docker, team-shared venv).

### zsh completion CURRENT off-by-one fix

`_airlab`'s 7 subcommand handlers (`ssh`, `auth`, `ping`, `sync`, `setup`, `launch`, `set_env`, `set_hosts`) had a latent bug: the `(( CURRENT == 1 ))` check that's supposed to fire `_airlab_complete_robots` / `_airlab_complete_targets` never matched. With the doubled-colon `*::args:->args` shift in the outer `_arguments`, `words[1]` is the subcommand itself, so the first user-supplied arg is at `CURRENT == 2`. Robot/target completion was dead code in real shells.

This was verified with a runtime probe (`print -ru2 "PROBE: CURRENT=$CURRENT words=(${words[*]})"`) and a PTY-driven interactive completion test:

| Input | Before | After |
|---|---|---|
| `airlab ssh <TAB>` | `--help` `--password` | 22 robot names + `--help` |
| `airlab sync <TAB>` | same | robots + `--help` |
| `airlab setup <TAB>` | same | robots + `local` + `--help` |
| `airlab sync <robot> --path=<TAB>` | nothing | dirs under `$AIRLAB_PATH` |

Fix: bump check to `CURRENT == 2` and `shift words; (( CURRENT-- ))` before the inner `_arguments -s` so flag completion after the positional also fires.

### Bash + zsh completion entries

`airlab vcs <TAB>` lists the new `check` / `tag` / `checkout` subcommands and their flags. `airlab <TAB>` lists `docker-clean`. Bash side mirrors zsh.

### Docs + README

- New per-command doc: `usr/local/bin/docs/set_hosts.md`.
- `version-control-commands.md`: new `check`, `tag`, `checkout` sections + an examples block.
- `setup.md`: updated for the remote setup canonicalization.
- README: Key Features bullet covers `vcs check` / `tag` / `checkout`; new sections under VCS for each; Tab Auto-Completion section reframes the `rm -f ~/.zcompdump* && exec zsh` snippet as a post-install/upgrade step with a one-line note explaining why zsh's compiled compdump cache needs the wipe.

## Strapsai-side PRs that landed in this sync

For traceability, the upstream merge corresponds to these strapsai PRs:

- strapsai/airlab#15 — `install` and `set_hosts` restoration
- strapsai/airlab#16 — `vcs check` + `vcs tag` + progress bars
- strapsai/airlab#17 — README for #16
- strapsai/airlab#18 — `docker-clean`
- strapsai/airlab#20 — `setup local` fixes
- strapsai/airlab#21 — `setup_remote` canonicalization (`ssh -tt` + `install_source` + clone-from-main)
- strapsai/airlab#22 — `vcs checkout`
- strapsai/airlab#23 — zsh `CURRENT` off-by-one + README cache-clear reframe

## Test plan

- [ ] Fresh `bash install.sh` from a kabirkedia checkout completes; `dpkg-deb --build` log includes `Recorded install source from git origin: kabirkedia/airlab`.
- [ ] `cat /usr/share/airlab/install_source` shows `kabirkedia/airlab` after install.
- [ ] `airlab vcs <TAB>` lists `check`, `tag`, `checkout` alongside the existing subcommands. Each `--help` works.
- [ ] `airlab vcs check` against a workspace with multiple clones flags any drift correctly. `--version-control` mode reads `$AIRLAB_PATH/version_control/*.yaml`.
- [ ] `airlab vcs tag v0.0.0-test --dry-run` previews tagging across PWD repos.
- [ ] `airlab vcs checkout main --no-fetch` runs cleanly when all repos are already on main; flips a feature-branched repo back to main otherwise.
- [ ] `airlab docker-clean --dry-run` previews cleanup.
- [ ] `airlab set_hosts` rewrites `/etc/hosts` between markers from `robot.conf` without touching other entries.
- [ ] `airlab setup local` on a fresh `$AIRLAB_PATH` writes `GROUP_NAME` to the actual group name; answering `N` to overwrite preserves `DOCKER_*_PATH` and `LAUNCH_FILE_PATH`.
- [ ] `airlab setup <robot>` against a fresh remote completes end-to-end: install.sh runs as the user under `ssh -tt`; `~/airlab_ws` on the robot mirrors `git clone main` of the host's origin.
- [ ] After install, `rm -f ~/.zcompdump* && exec zsh`, then `airlab ssh <TAB>` shows robot names; `airlab sync <robot> --path=<TAB>` completes dirs under `$AIRLAB_PATH`.
- [ ] Existing commands (`init`, `pull`, `push`, `status`, `update`, `ssh`, `auth`, `ping`, `sync`, `launch`, `set_env`, `docker-build/up/join/list`, `cd`) continue to work as before.

Happy to split this into per-feature PRs if that's easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)